### PR TITLE
feat: parallel rendering + file loading

### DIFF
--- a/log-viewer/modules/Analysis.js
+++ b/log-viewer/modules/Analysis.js
@@ -41,7 +41,7 @@ function addNodeToMap(map, node, key) {
 	}
 }
 
-export default function analyseMethods(rootMethod) {
+export default async function analyseMethods(rootMethod) {
 	const methodMap = {};
 
 	addNodeToMap(methodMap, rootMethod);
@@ -128,7 +128,7 @@ function renderAnalysisLine(name, count, duration, netDuration, isBold) {
 	return analysisRow;
 }
 
-export function renderAnalysis() {
+export async function renderAnalysis() {
 	const sortFieldElm = document.getElementById('sortField'),
 		sortField = sortFieldElm.value,
 		sortAscendingElm = document.getElementById('sortAscending'),

--- a/log-viewer/modules/Database.js
+++ b/log-viewer/modules/Database.js
@@ -39,7 +39,7 @@ function findDb(node, dmlMap, soqlMap) {
 	}
 }
 
-export default function analyseDb(rootMethod) {
+export default async function analyseDb(rootMethod) {
 	dmlMap = {};
 	soqlMap = {};
 
@@ -112,7 +112,7 @@ function renderSummary(title, entryMap) {
 	return mainNode;
 }
 
-export function renderDb() {
+export async function renderDb() {
 	const dbContainer = document.getElementById('dbContent');
 
 	dbContainer.innerHTML = '';

--- a/log-viewer/modules/LineParser.js
+++ b/log-viewer/modules/LineParser.js
@@ -819,7 +819,7 @@ function parseLine(line, lastEntry) {
 	return entry;
 }
 
-export default function parseLog(log) {
+export default async function parseLog(log) {
 	const start = log.indexOf('EXECUTION_STARTED');
 	const raw = log.substring(start, log.length);
 	let rawLines = raw.split('\n');

--- a/log-viewer/modules/Main.js
+++ b/log-viewer/modules/Main.js
@@ -22,7 +22,7 @@ const settingsPattern = /\d+\.\d+\sAPEX_CODE,\w+;APEX_PROFILING,.+/;
 
 let logSize;
 
-function setStatus(name, path, status, color) {
+async function setStatus(name, path, status, color) {
 	const statusHolder = document.getElementById('status'),
 		nameSpan = document.createElement('span'),
 		nameLink = document.createElement('a'),
@@ -57,6 +57,7 @@ function setStatus(name, path, status, color) {
 			statusHolder.appendChild(reasonSpan);
 		});
 	}
+	await timeout(10);
 }
 
 function getLogSettings(log) {
@@ -76,7 +77,7 @@ function getLogSettings(log) {
 	}, {});
 }
 
-function markContainers(node, targetType, propertyName) {
+async function markContainers(node, targetType, propertyName) {
 	const children = node.children,
 		len = children.length;
 
@@ -93,7 +94,7 @@ function markContainers(node, targetType, propertyName) {
 	return node[propertyName];
 }
 
-function insertPackageWrappers(node) {
+async function insertPackageWrappers(node) {
 	const children = node.children,
 		isParentDml = node.type === 'DML_BEGIN';
 
@@ -149,7 +150,7 @@ function timer(text) {
 	startTime = time;
 }
 
-function renderLogSettings(logSettings) {
+async function renderLogSettings(logSettings) {
 	const holder = document.getElementById('logSettings');
 
 	holder.innerHTML = '';
@@ -174,44 +175,39 @@ function renderLogSettings(logSettings) {
 	}
 }
 
-function displayLog(log, name, path) {
+async function displayLog(log, name, path) {
 	logSize = log.length;
-	setStatus(name, path, 'Processing...', 'black');
-	setTimeout(() => {			// timeout required to display the status
-		timer('renderLogSettings');
-		renderLogSettings(getLogSettings(log));
-		timer('parseLog');
-		parseLog(log);
-		timer('getRootMethod');
-		const rootMethod = getRootMethod();
+	await setStatus(name, path, 'Processing...', 'black');
+	timer('parseLog');
+	await Promise.all([
+		renderLogSettings(getLogSettings(log)), 
+		parseLog(log)]);
+	timer('getRootMethod');
 
-		timer('setNamespaces');
-		setNamespaces(rootMethod);
-		timer('markContainers - DML');
-		markContainers(rootMethod, 'DML_BEGIN', 'containsDml');
-		timer('markContainers - SOQL');
-		markContainers(rootMethod, 'SOQL_EXECUTE_BEGIN', 'containsSoql');
-		timer('insertPackageWrappers');
-		insertPackageWrappers(rootMethod);
-		timer('analyseMethods');
-		analyseMethods(rootMethod);
-		timer('analyseDb');
-		analyseDb(rootMethod);
+	timer('analyse');
+	const rootMethod = getRootMethod();
+	await Promise.all([
+		setNamespaces(rootMethod), 
+		markContainers(rootMethod, 'DML_BEGIN', 'containsDml'),
+		markContainers(rootMethod, 'SOQL_EXECUTE_BEGIN', 'containsSoql'),
+		insertPackageWrappers(rootMethod),
+		analyseMethods(rootMethod),
+		analyseDb(rootMethod)
+	]);
 
-		setStatus(name, path,'Rendering...', 'black');
-		setTimeout(() => {		// timeout required to display the status
-			timer('renderTreeView');
-			renderTreeView(rootMethod);
-			timer('renderTimeline');
-			renderTimeline(rootMethod);
-			timer('renderAnalysis');
-			renderAnalysis();
-			timer('renderDb');
-			renderDb();
-			timer('');
-			setStatus(name, path,'Ready', truncated.length > 0 ? 'red' : 'green');
-		}, 10);
-	}, 10);
+	await setStatus(name, path, 'Rendering...', 'black');
+	timer('renderViews');
+	await Promise.all([
+		renderTreeView(rootMethod),
+		renderTimeline(rootMethod),
+		renderAnalysis(),
+		renderDb()
+	]);
+	setStatus(name, path, 'Ready', truncated.length > 0 ? 'red' : 'green');
+}
+
+function timeout(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 function readLog() {
@@ -231,8 +227,7 @@ function onTabSelect(evt) {
 }
 
 function onInit(evt) {
-	const
-		tabHolder = document.querySelector('.tabHolder');
+	const tabHolder = document.querySelector('.tabHolder');
 
 	tabHolder.querySelectorAll('.tab').forEach(t => t.addEventListener('click', onTabSelect));
 

--- a/log-viewer/modules/NamespaceExtrator.js
+++ b/log-viewer/modules/NamespaceExtrator.js
@@ -30,7 +30,7 @@ function extractNamespace(namespaces, text) {
         return null    
 }
 
-function setNamespaces(node) {
+async function setNamespaces(node) {
     const namespaces = collectNamespaces(node)
     const children = node.children;
 	let i;

--- a/log-viewer/modules/Timeline.js
+++ b/log-viewer/modules/Timeline.js
@@ -194,7 +194,7 @@ function calculateSizes(canvas) {
 	canvas.style.height = displayHeight + 'px';
 }
 
-export default function renderTimeline(rootMethod) {
+export default async function renderTimeline(rootMethod) {
 	const canvas = document.getElementById('timeline'),
 		ctx = canvas.getContext('2d');
 

--- a/log-viewer/modules/TreeView.js
+++ b/log-viewer/modules/TreeView.js
@@ -347,7 +347,7 @@ function renderTree() {
 	treeContainer.appendChild(renderTreeNode(treeRoot, null));
 }
 
-export default function renderTreeView(rootMethod) {
+export default async function renderTreeView(rootMethod) {
 	treeRoot = rootMethod;
 	renderTree();
 }

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -2,42 +2,40 @@
  * Copyright (c) 2020 FinancialForce.com, inc. All rights reserved.
  */
 
-import { ExtensionContext, workspace } from 'vscode';
-import { LoadLogFile } from './commands/LoadLogFile';
-import { ShowLogFile } from './commands/ShowLogFile';
-import { Display } from './Display';
-import { SymbolFinder } from "./SymbolFinder"
-import { VSWorkspace } from './workspace/VSWorkspace';
+import { ExtensionContext, workspace } from "vscode";
+import { LoadLogFile } from "./commands/LoadLogFile";
+import { ShowLogFile } from "./commands/ShowLogFile";
+import { Display } from "./Display";
+import { SymbolFinder } from "./SymbolFinder";
+import { VSWorkspace } from "./workspace/VSWorkspace";
 
 export class Context {
-
-  symbolFinder = new SymbolFinder()
-  context: ExtensionContext
-  display: Display
-  workspaces: VSWorkspace[] = []
-  namespaces: string[] = []
+  symbolFinder = new SymbolFinder();
+  context: ExtensionContext;
+  display: Display;
+  workspaces: VSWorkspace[] = [];
+  namespaces: string[] = [];
 
   constructor(context: ExtensionContext, display: Display) {
     this.context = context;
     this.display = display;
 
     if (workspace.workspaceFolders) {
-        this.workspaces = workspace.workspaceFolders.map((folder) => {
-            return new VSWorkspace(folder)
-        })
+      this.workspaces = workspace.workspaceFolders.map((folder) => {
+        return new VSWorkspace(folder);
+      });
     }
 
-    LoadLogFile.apply(this)
-    ShowLogFile.apply(this)
+    LoadLogFile.apply(this);
+    ShowLogFile.apply(this);
   }
 
   findSymbol(wsPath: string, symbol: string): string | null {
     try {
-        return this.symbolFinder.findSymbol(wsPath, symbol);
+      return this.symbolFinder.findSymbol(wsPath, symbol);
     } catch (err) {
-        this.display.showErrorMessage(err.message)
-        return null
+      this.display.showErrorMessage(err.message);
+      return null;
     }
   }
 }
-

--- a/src/Display.ts
+++ b/src/Display.ts
@@ -11,7 +11,9 @@ export class Display {
   constructor(context: ExtensionContext) {}
 
   output(message: string, showChannel: boolean = false) {
-    if (showChannel) this.outputChannel.show(true);
+    if (showChannel) {
+      this.outputChannel.show(true);
+    }
     this.outputChannel.appendLine(message);
   }
 

--- a/src/SymbolFinder.ts
+++ b/src/SymbolFinder.ts
@@ -16,7 +16,11 @@ export class SymbolFinder {
   findSymbol(wsPath: string, symbol: string): string {
     const ws = Workspaces.get(wsPath);
     const path = ws.findType(symbol);
-    if (path == null) throw new SymbolFinderError(`Type '${symbol}' was not found in workspace`);
+    if (path === null) {
+      throw new SymbolFinderError(
+        `Type '${symbol}' was not found in workspace`
+      );
+    }
     return path;
   }
 }

--- a/src/commands/LogView.ts
+++ b/src/commands/LogView.ts
@@ -81,8 +81,6 @@ export class LogView {
     );
     const index = path.join(logViewerRoot, "index.html");
     const bundle = path.join(logViewerRoot, "dist", "bundle.js");
-    const indexSrc = (await fs.readFile(index)).toString("utf8");
-    const bundleSrc = (await fs.readFile(bundle)).toString("utf8");
 
     const htmlWithLog = await LogView.insertAtToken(
       indexSrc,
@@ -111,6 +109,10 @@ export class LogView {
     );
     return htmlWithBundle;
   }
+    const [indexSrc, bundleSrc] = await Promise.all([
+      fs.readFile(index, "utf-8"),
+      fs.readFile(bundle, "utf-8"),
+    ]);
 
   private static async insertAtToken(
     str: string,

--- a/src/commands/LogView.ts
+++ b/src/commands/LogView.ts
@@ -82,47 +82,24 @@ export class LogView {
     const index = path.join(logViewerRoot, "index.html");
     const bundle = path.join(logViewerRoot, "dist", "bundle.js");
 
-    const htmlWithLog = await LogView.insertAtToken(
-      indexSrc,
-      "@@logTxt",
-      logContents
-    );
-    const htmlWithLogName = await LogView.insertAtToken(
-      htmlWithLog,
-      "@@name",
-      logName
-    );
-    const htmlWithLogPath = await LogView.insertAtToken(
-      htmlWithLogName,
-      "@@path",
-      logPath
-    );
-    const htmlWithNS = await LogView.insertAtToken(
-      htmlWithLogPath,
-      "@@ns",
-      namespaces.join(",")
-    );
-    const htmlWithBundle = await LogView.insertAtToken(
-      htmlWithNS,
-      "@@bundle",
-      bundleSrc
-    );
-    return htmlWithBundle;
-  }
     const [indexSrc, bundleSrc] = await Promise.all([
       fs.readFile(index, "utf-8"),
       fs.readFile(bundle, "utf-8"),
     ]);
 
-  private static async insertAtToken(
-    str: string,
-    token: string,
-    insert: string
-  ): Promise<string> {
-    if (str.indexOf(token) > -1) {
-      const splits = str.split(token);
-      return splits[0] + insert + splits[1];
-    }
-    return str;
+    const toReplace: { [key: string]: string } = {
+      "@@logTxt": logContents,
+      "@@name": logName,
+      "@@path": logPath,
+      "@@ns": namespaces.join(","),
+      "@@bundle": bundleSrc,
+    };
+
+    return indexSrc.replace(
+      /@@logTxt|@@name|@@path|@@ns|@@bundle/gi,
+      function (matched) {
+        return toReplace[matched];
+      }
+    );
   }
 }

--- a/src/commands/LogView.ts
+++ b/src/commands/LogView.ts
@@ -37,7 +37,9 @@ export class LogView {
         if (request.typeName) {
           const parts = request.typeName.split("-");
           let line;
-          if (parts.length > 1) line = parseInt(parts[1]);
+          if (parts.length > 1) {
+            line = parseInt(parts[1]);
+          }
           OpenFileInPackage.openFileForSymbol(wsPath, context, parts[0], line);
         } else if (request.path) {
           context.display.showFile(request.path);

--- a/src/commands/ShowLogFile.ts
+++ b/src/commands/ShowLogFile.ts
@@ -29,18 +29,18 @@ export class ShowLogFile {
   }
 
   private static async command(context: Context, uri: Uri): Promise<void> {
-    let filePath;
-
-    if (uri) filePath = uri.fsPath;
-    else if (window.activeTextEditor)
-      filePath = window.activeTextEditor.document.uri.fsPath;
+    const filePath = uri?.fsPath || window?.activeTextEditor?.document.fileName;
 
     if (filePath) {
-      const ws = await QuickPickWorkspace.pickOrReturn(context);
       const name = path.parse(filePath).name;
-      const view = await LogView.createView(ws, context, name);
-      const fileContents = (await fs.readFile(filePath)).toString("utf8");
-      await LogView.appendView(view, context, name, filePath, fileContents);
+      const ws = await QuickPickWorkspace.pickOrReturn(context);
+
+      const [view, fileContent] = await Promise.all([
+        LogView.createView(ws, context, name),
+        fs.readFile(filePath, "utf-8"),
+      ]);
+
+      LogView.appendView(view, context, name, filePath, fileContent);
     } else {
       context.display.showErrorMessage(
         "No file selected to display log analysis"

--- a/src/display/QuickPick.ts
+++ b/src/display/QuickPick.ts
@@ -49,8 +49,7 @@ export class QuickPick {
   ): Promise<T[]> {
     return QuickPick.showQuickPick(items, options).then((oneOrMany) => {
       if (oneOrMany) {
-        if (options.canPickMany) return oneOrMany as T[];
-        else return [oneOrMany as T];
+        return options.canPickMany ? (oneOrMany as T[]) : [oneOrMany as T];
       }
       return [];
     });

--- a/src/display/QuickPickWorkspace.ts
+++ b/src/display/QuickPickWorkspace.ts
@@ -14,16 +14,17 @@ export class QuickPickWorkspace {
         context.workspaces.map((ws) => new Item(ws.name(), ws.path(), "")),
         new Options("Select a workspace:")
       );
-      if (workspace.length == 1) {
+
+      if (workspace.length === 1) {
         return workspace[0].description;
       } else {
         throw new Error("No workspace selected");
       }
-    } else if (context.workspaces.length == 1) {
+    } else if (context.workspaces.length === 1) {
       return context.workspaces[0].path();
     } else {
       if (window.activeTextEditor) {
-        return path.parse(window.activeTextEditor.document.uri.fsPath).dir;
+        return path.parse(window.activeTextEditor.document.fileName).dir;
       } else {
         throw new Error("No workspace selected");
       }

--- a/src/sfdx/Command.ts
+++ b/src/sfdx/Command.ts
@@ -21,7 +21,7 @@ export class Command {
           stdOut: Buffer | String,
           stdErr: Buffer | String
         ) => {
-          if (error == null) {
+          if (error === null) {
             const out = stdOut as Buffer;
             resolve(out.toString("utf8"));
           } else {
@@ -37,7 +37,7 @@ export class Command {
     stdOut: Buffer
   ): Error {
     const out = stdOut.toString("utf-8");
-    if (out != null && out.length > 0) {
+    if (out !== null && out.length > 0) {
       // sometimes we get detailed message fields back on stdout in json objects
       try {
         const tryGenericError = JSON.parse(out) as Error;

--- a/src/sfdx/logs/GetLogFiles.ts
+++ b/src/sfdx/logs/GetLogFiles.ts
@@ -4,6 +4,7 @@
 import { SFDX, SFDXResponse } from "../SFDX";
 
 export interface GetLogFilesResult {
+  /* eslint-disable @typescript-eslint/naming-convention */
   Id: String;
   Application: string;
   DurationMilliseconds: number;


### PR DESCRIPTION
**display log (log rendering)**
Changes the analysis and rendering to happen in parallel where possible.
This improves performance especially with larger logs.

**load log file cmd executes more in parallel**
rendering the initial view and reading the log file now happen in parallel.

** show log file cmd more parallel processing**
The initial view rendering and reading the log file will now happen in parallel.

**getViewContent does more processing in parallel**
index.html + bundle.js files are loaded in parallel

#31 
