### PR TITLE
bug: truncate text on status bar

### DIFF
--- a/log-viewer/modules/Main.ts
+++ b/log-viewer/modules/Main.ts
@@ -74,12 +74,24 @@ async function setStatus(
 
   if (Array.isArray(truncated)) {
     truncated.forEach((entry) => {
+      const tooltipSpan = document.createElement("span");
+      tooltipSpan.className = "tooltiptext";
+      tooltipSpan.innerText = entry[0];
+
+      let message = entry[0];
+      message =
+        message.length > 80 ? message.substring(0, 80) + "..." : message;
       const reasonSpan = document.createElement("span");
 
-      reasonSpan.innerText = entry[0];
-      reasonSpan.className = "reason";
-      if (entry[2]) reasonSpan.style.backgroundColor = entry[2];
-      if (statusHolder) statusHolder.appendChild(reasonSpan);
+      reasonSpan.innerText = message;
+      reasonSpan.className = "reason tooltip";
+      reasonSpan.appendChild(tooltipSpan);
+      if (entry[2]) {
+        reasonSpan.style.backgroundColor = entry[2];
+      }
+      if (statusHolder) {
+        statusHolder.appendChild(reasonSpan);
+      }
     });
   }
   await timeout(10);

--- a/log-viewer/resources/css/Status.css
+++ b/log-viewer/resources/css/Status.css
@@ -1,25 +1,45 @@
 .statusBar {
-    margin-top: 10px;
-	display: flex;
+  margin-top: 10px;
+  display: flex;
 }
 #status {
-	display: flex;
-	align-items: center;
-	font-size: 10pt;
-	margin-bottom: 5px;
-	margin-top: 5px;
+  display: flex;
+  align-items: center;
+  font-size: 10pt;
+  margin-bottom: 5px;
+  margin-top: 5px;
 }
 .statusPad {
-	flex-grow: 1;
+  flex-grow: 1;
 }
 .helpIcon {
-	width: 24px;
-	height: 24px;
+  width: 24px;
+  height: 24px;
 }
 .reason {
-	display: inline-block;
-	padding: 2px;
-	padding-left: 4px;
-	padding-right: 4px;
-	margin-left: 5px;
+  display: inline-block;
+  padding: 2px;
+  padding-left: 4px;
+  padding-right: 4px;
+  margin-left: 5px;
+}
+.tooltip {
+  position: relative;
+  display: inline-block;
+}
+.tooltip .tooltiptext {
+  visibility: hidden;
+  padding: 5px;
+  background-color: var(--vscode-editor-background);
+  color: var(--vscode-editor-foreground);
+  word-break: break-word;
+  width: 75%;
+  position: absolute;
+  z-index: 1;
+  top: 100%;
+  left: 50%;
+  transform: translate(-50%, 0px);
+}
+.tooltip:hover .tooltiptext {
+  visibility: visible;
 }


### PR DESCRIPTION
This ensure that the call tree can still be interacted with
when the error statuses are very large.

The message is truncated to 80 characters and the full text show in a tooltip.


fixes #39
![truncate-status-fix](https://user-images.githubusercontent.com/4013877/135132232-3e03f0ca-fdf1-4918-97fe-bf8239869738.png)
 