### PR TITLE
feat: zoom on timeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Node
-    - uses: actions/setup-node@v2
+      uses: actions/setup-node@v2
       with:
         node-version: '16'
     - name: Install vsce

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Node
-      uses: actions/setup-node@v2-beta
+    - uses: actions/setup-node@v2
       with:
-        node-version: '12'
+        node-version: '16'
     - name: Install vsce
       run: npm install --global vsce
     - name: Dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Node
-      uses: actions/setup-node@v2-beta
+    - uses: actions/setup-node@v2
       with:
-        node-version: '12'
+        node-version: '16'
     - name: Install vsce
       run: npm install --global vsce
     - name: Dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Node
-    - uses: actions/setup-node@v2
+      uses: actions/setup-node@v2
       with:
         node-version: '16'
     - name: Install vsce

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Zoom on timeline ([#33][#33])
   - zoom to an accuracy of 0.001ms, time markers are shown with a ms time value and white line e.g 9600.001 ms
   - scroll up and down on the mouse to zoom in and out
-  - zoom is based on position of mouse pointer, ensuring that postion is kept on screen when zoomed in or out
+  - zoom is based on position of mouse pointer, ensuring that position is kept on screen when zoomed in or out
   - scroll left and right on the mouse to move the time line left are right, when zoomed
   - click the mouse down and drag to move the timeline around both in the x and y direction, when zoomed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Timeline shows a tooltip for log events ([#52][#52])
-  - Shown when hovering the red (errors), blue (unexpected-end) and green (skipped-lines) sections on the timeline.
 - Database tab shows the methods each SOQL or DML statement was made from ([#11][#11])
   - The method name can be clicked to navigate to it in the call tree
+- Timeline shows a tooltip for log events ([#52][#52])
+  - Shown when hovering the red (errors), blue (unexpected-end) and green (skipped-lines) sections on the timeline.
+- Zoom on timeline ([#33][#33])
+  - zoom to an accuracy of 0.001ms, time markers are shown with a ms time value and white line e.g 9600.001 ms
+  - scroll up and down on the mouse to zoom in and out
+  - zoom is based on position of mouse pointer, ensuring that postion is kept on screen when zoomed in or out
+  - scroll left and right on the mouse to move the time line left are right, when zoomed
+  - click the mouse down and drag to move the timeline around both in the x and y direction, when zoomed
 
 ### Changed
 
@@ -30,6 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Hide details, hide system calls and hide formulas on the call tree to work again [#45][#45]
+
+### Removed
+
+- Timeline Shrink-to-fit checkbox was replaced with zoom feature ([#33][#33])
 
 ## [1.3.5] - December 2020
 
@@ -64,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#11]: https://github.com/financialforcedev/debug-log-analyzer/issues/11
 [#18]: https://github.com/financialforcedev/debug-log-analyzer/issues/18
 [#22]: https://github.com/financialforcedev/debug-log-analyzer/issues/22
+[#33]: https://github.com/financialforcedev/debug-log-analyzer/issues/33
 [#34]: https://github.com/financialforcedev/debug-log-analyzer/issues/34
 [#42]: https://github.com/financialforcedev/debug-log-analyzer/issues/42
 [#45]: https://github.com/financialforcedev/debug-log-analyzer/issues/45

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,27 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Timeline shows a tooltip for log events ([#52](https://github.com/financialforcedev/debug-log-analyzer/issues/52))
-    - Shown when hovering the red (errors), blue (unexpected-end) and green (skipped-lines) sections on the timeline.
-- Database tab shows the methods each SOQL or DML statement was made from ([#11](https://github.com/financialforcedev/debug-log-analyzer/issues/11))
-    - The method name can be clicked to navigate to it in the call tree
+- Timeline shows a tooltip for log events ([#52][#52])
+  - Shown when hovering the red (errors), blue (unexpected-end) and green (skipped-lines) sections on the timeline.
+- Database tab shows the methods each SOQL or DML statement was made from ([#11][#11])
+  - The method name can be clicked to navigate to it in the call tree
 
 ### Changed
 
-- Convert from scala to typescript ([#22](https://github.com/financialforcedev/debug-log-analyzer/issues/22) [#34](https://github.com/financialforcedev/debug-log-analyzer/issues/34))
-- Load log shows loading feedback whilst waiting for logs to be retrieved ([#18](https://github.com/financialforcedev/debug-log-analyzer/issues/18))
-- Open an empty log view whilst waiting for selected log to be downloaded, parsed and rendered ([#18](https://github.com/financialforcedev/debug-log-analyzer/issues/18))
-- Log will be loaded from disk if previously downloaded ([#18](https://github.com/financialforcedev/debug-log-analyzer/issues/18))
-- Renamed the `Log: Show Log Analysis` command to `Log: Show Apex Log Analysis` [#48](https://github.com/financialforcedev/debug-log-analyzer/issues/48)
-    - For consistency with the `Log: Load Apex Log For Analysis` command
-- Block text on call tree displayed on new lines rather than one line separated by a | character ([#50](https://github.com/financialforcedev/debug-log-analyzer/issues/50))
-- Call tree to show text for all log lines and not just time taken ([#42](https://github.com/financialforcedev/debug-log-analyzer/issues/42))
-- Faster log loading due to a change in how the JavaScript is loaded on the page ([#11](https://github.com/financialforcedev/debug-log-analyzer/issues/11))
-- Faster log parsing and timeline rendering ([#63](https://github.com/financialforcedev/debug-log-analyzer/issues/63))
+- Convert from scala to typescript ([#22][#22] [#34][#34])
+- Load log shows loading feedback whilst waiting for logs to be retrieved ([#18][#18])
+- Open an empty log view whilst waiting for selected log to be downloaded, parsed and rendered ([#18][#18])
+- Log will be loaded from disk if previously downloaded ([#18][#18])
+- Renamed the `Log: Show Log Analysis` command to `Log: Show Apex Log Analysis` [#48][#48]
+  - For consistency with the `Log: Load Apex Log For Analysis` command
+- Block text on call tree displayed on new lines rather than one line separated by a | character ([#50][#50])
+- Call tree to show text for all log lines and not just time taken ([#42][#42])
+- Faster log loading due to a change in how the JavaScript is loaded on the page ([#11][#11])
+- Faster log parsing and timeline rendering ([#63][#63])
 
 ### Fixed
 
-- Hide details, hide system calls and hide formulas on the call tree to work again [#45](https://github.com/financialforcedev/debug-log-analyzer/issues/45)
+- Hide details, hide system calls and hide formulas on the call tree to work again [#45][#45]
 
 ## [1.3.5] - December 2020
 
@@ -60,3 +60,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Misc Visual tweaks
 - Add explorer menu item
 - Provide more information when selecting log to download
+
+[#11]: https://github.com/financialforcedev/debug-log-analyzer/issues/11
+[#18]: https://github.com/financialforcedev/debug-log-analyzer/issues/18
+[#22]: https://github.com/financialforcedev/debug-log-analyzer/issues/22
+[#34]: https://github.com/financialforcedev/debug-log-analyzer/issues/34
+[#42]: https://github.com/financialforcedev/debug-log-analyzer/issues/42
+[#45]: https://github.com/financialforcedev/debug-log-analyzer/issues/45
+[#48]: https://github.com/financialforcedev/debug-log-analyzer/issues/48
+[#50]: https://github.com/financialforcedev/debug-log-analyzer/issues/50
+[#52]: https://github.com/financialforcedev/debug-log-analyzer/issues/52
+[#63]: https://github.com/financialforcedev/debug-log-analyzer/issues/63

--- a/README.md
+++ b/README.md
@@ -1,32 +1,27 @@
-Apex Log Analyzer for Salesforce
-================================
+# Apex Log Analyzer for Salesforce
 
 An analyzer for Salesforce debug logs aimed at making performance analysis much easier and quicker. You may also find it generally useful for quickly understanding how your code is executing.
 
 The main view provides a flame graph for visualising code execution:
 
-
 ![Another](https://raw.githubusercontent.com/financialforcedev/debug-log-analyzer/main/lana/dist/images/FlameGraph.gif)
 
-Hovering over an element provides information on the item. If you click on an item it will take you to the call 
+Hovering over an element provides information on the item. If you click on an item it will take you to the call
 navigatable stack view.
 
 Other views are available to show a sorted list of the methods invoked and the SOQL operations performed.
 
-Quick Start
-===========
+## Quick Start
 
 You can start the analysis either from a log you have already downloaded or by downloading a log from an org to view.
-To download run 'Log: Load Apex Log for Analysis' from the command palette. To open an existing log file right click it 
-and select 'Log: Show Log Analysis'.On larger logs the analysis window make take a few seconds to appear.
+To download run 'Log: Load Apex Log for Analysis' from the command palette. To open an existing log file right click it
+and select 'Log: Show Apex Log Analysis'. On larger logs the analysis window make take a few seconds to appear.
 
-WARNING
-=======
+## WARNING
 
-The quality of data shown to you depends entirely on the data contained in the log files. Special care should be 
+The quality of data shown to you depends entirely on the data contained in the log files. Special care should be
 taken when looking at log files that have been truncated as you are only seeing a part of the execution and that
 may lead you to misunderstand what is really happening.
 
-In general you should always set the APEX_CODE debug flag to be FINE or higher for a log to be used for analysis. 
+In general you should always set the APEX_CODE debug flag to be FINE or higher for a log to be used for analysis.
 With a lower setting the log will likely not contain enough detail for meaningful analysis.
-   

--- a/docs/index.markdown
+++ b/docs/index.markdown
@@ -1,34 +1,37 @@
-
 For best results we recommend setting Apex Code logging to FINE or better.
 
 ## Views
 
 ### The "Timeline" Tab
-This tab shows the call tree as a timeline graph. Time runs left-to-right and nested calls run bottom-to-top. The graph shows in "Shrinks-to-fit" mode by default, to view a scrollable graph disable "Shrink-to-fit" checkbox. A color key at the bottom of the graph shows the meaning of the colors used for types of call. Information about nodes on the graph is shown as a tooltip when hovering the mouse over a node.
+
+This tab shows the call tree as a timeline graph. Time runs left-to-right and nested calls run bottom-to-top. A color key at the bottom of the graph shows the meaning of the colors used for types of call. Information about nodes on the graph is shown as a tooltip when hovering the mouse over a node.
 
 Clicking on a timeline node will take you to the entry in the "Call Tree".
 
 ### The "Call Tree" Tab
+
 This tab shows the call tree for the log execution.
 
 The tree can be expanded/collapsed with the +/- buttons on each method or with the "Expand All" / "Collapse All" buttons in the toolbar. To show other information (e.g. SOQL statements or variable assignments) in the tree, un-tick the hide details checkbox. There are also filter checkboxes to "Hide system calls" and "Hide formulas". The prefix '(S)' is used to indicate callers of methods which perform SOQL and '(D)' is used to indicate callers of methods that perform DML.
 
 ### The "Analysis" Tab
-This tab has aggregated times showing: *Count*, *Total Duration* and *Net duration* for each tree node. The toolbar controls sorting. The sort is multi-field and can be:
 
-* Total Duration (followed by count and then name)
-* Net duration (followed by count and then name)
-* Count (followed by duration and then name)
-* Name (followed by count and then duration)
+This tab has aggregated times showing: _Count_, _Total Duration_ and _Net duration_ for each tree node. The toolbar controls sorting. The sort is multi-field and can be:
+
+- Total Duration (followed by count and then name)
+- Net duration (followed by count and then name)
+- Count (followed by duration and then name)
+- Name (followed by count and then duration)
 
 The sort order can also toggle between ascending and descending.
 
 ### The "Database" Tab
-This tab aggregates DML and SOQL statements by text, providing *Count* and *Row* totals for each. This helps identify the cause of *SOQL 101* exceptions - it is usually easy to see where a query is not bulkified.
+
+This tab aggregates DML and SOQL statements by text, providing _Count_ and _Row_ totals for each. This helps identify the cause of _SOQL 101_ exceptions - it is usually easy to see where a query is not bulkified.
 
 It may also show where we used our row limit if we run-out of DML.
 
 Be aware that totals may exceed the normal limits due to:
 
-* Unit tests - we get the extra setup limits outside *startTest* / *stopTest*.
-* Multiple packages - some limits are per package.
+- Unit tests - we get the extra setup limits outside _startTest_ / _stopTest_.
+- Multiple packages - some limits are per package.

--- a/log-viewer/modules/Main.ts
+++ b/log-viewer/modules/Main.ts
@@ -285,7 +285,7 @@ function onInit(evt: Event) {
 
   const helpButton = document.querySelector(".helpLink");
   if (helpButton) {
-    helpButton.addEventListener("click", () => hostService().openHelp())
+    helpButton.addEventListener("click", () => hostService().openHelp());
   }
 
   readLog();

--- a/log-viewer/modules/Timeline.ts
+++ b/log-viewer/modules/Timeline.ts
@@ -100,11 +100,12 @@ function drawScale(ctx: CanvasRenderingContext2D) {
   ctx.textBaseline = "top";
   ctx.textAlign = "left";
 
-  const xStep = 1000000000, // 1/10th second
-    detailed = scaleX > 0.0000002, // threshHold for 1/10ths and text
-    labeled = scaleX > 0.00000002; // threshHold for labels
+  // 1ms = 0.001s
+  const xStep = 1000000000, // 1/10th second (0.1ms)
+    detailed = scaleX > 0.000002, // threshHold for 1/10 ths (100 ms)and text
+    labeled = scaleX > 0.0000002; // threshHold for labels
 
-  const textHeight = -logicalHeight + 2;
+  const textHeight = -displayHeight + 2;
   const scaledXPosition = xStep * scaleX;
 
   const wholeSeconds = ~~(0.5 + maxX / 1000000000);
@@ -112,8 +113,8 @@ function drawScale(ctx: CanvasRenderingContext2D) {
   ctx.fillStyle = "#F88962";
   ctx.beginPath();
   for (let i = 0; i <= wholeSeconds; i++) {
-    const xPos = ~~(0.5 + scaledXPosition * i);
-    ctx.moveTo(xPos, -logicalHeight);
+    const xPos = ~~(0.5 + scaledXPosition * i - centerOffset);
+    ctx.moveTo(xPos, -displayHeight);
     ctx.lineTo(xPos, 0);
 
     if (labeled) {
@@ -126,12 +127,13 @@ function drawScale(ctx: CanvasRenderingContext2D) {
     ctx.strokeStyle = "#E0E0E0";
     ctx.fillStyle = "#808080";
     ctx.beginPath();
+    // each 100 ms marker
     const tenthsOfSeconds = maxX / 100000000; // convert nano to tenths e.g 11 which would represent 1.1
     for (let i = 1; i <= tenthsOfSeconds; i++) {
       const wholeNumber = i % 10 === 0;
       if (!wholeNumber) {
-        const xPos = ~~(0.5 + 100000000 * scaleX * i);
-        ctx.moveTo(xPos, -logicalHeight);
+        const xPos = ~~(0.5 + 100000000 * scaleX * i - centerOffset);
+        ctx.moveTo(xPos, -displayHeight);
         ctx.lineTo(xPos, 0);
 
         if (labeled) {

--- a/log-viewer/modules/Timeline.ts
+++ b/log-viewer/modules/Timeline.ts
@@ -256,7 +256,7 @@ function resizeFont() {
 }
 
 export default async function renderTimeline(rootMethod: RootNode) {
-  container = document.getElementById("timelineScroll") as HTMLDivElement;
+  container = document.getElementById("timelineWrapper") as HTMLDivElement;
   canvas = document.getElementById("timeline") as HTMLCanvasElement;
   ctx = canvas.getContext("2d", { alpha: false });
   timelineRoot = rootMethod;
@@ -353,10 +353,10 @@ function findByPosition(
 
 function showTooltip(offsetX: number, offsetY: number) {
   if (!dragging) {
-    const timelineScroll = document.getElementById("timelineScroll");
+    const timelineWrapper = document.getElementById("timelineWrapper");
     const tooltip = document.getElementById("tooltip");
 
-    if (timelineScroll && tooltip) {
+    if (timelineWrapper && tooltip) {
       const depth = ~~(
         ((displayHeight - offsetY - verticalOffset) / realHeight) *
         maxY
@@ -370,7 +370,7 @@ function showTooltip(offsetX: number, offsetY: number) {
           offsetY,
           tooltipText,
           tooltip,
-          timelineScroll
+          timelineWrapper
         );
       }
     }
@@ -443,23 +443,23 @@ function showTooltipWithText(
   offsetY: number,
   tooltipText: HTMLDivElement,
   tooltip: HTMLElement,
-  timelineScroll: HTMLElement
+  timelineWrapper: HTMLElement
 ) {
-  if (tooltipText && tooltip && timelineScroll) {
+  if (tooltipText && tooltip && timelineWrapper) {
     let posLeft = offsetX + 10,
       posTop = offsetY + 2;
 
-    if (posLeft + tooltip.offsetWidth > timelineScroll.offsetWidth) {
-      posLeft = timelineScroll.offsetWidth - tooltip.offsetWidth;
+    if (posLeft + tooltip.offsetWidth > timelineWrapper.offsetWidth) {
+      posLeft = timelineWrapper.offsetWidth - tooltip.offsetWidth;
     }
-    if (posTop + tooltip.offsetHeight > timelineScroll.offsetHeight) {
+    if (posTop + tooltip.offsetHeight > timelineWrapper.offsetHeight) {
       posTop -= tooltip.offsetHeight + 4;
       if (posTop < -100) {
         posTop = -100;
       }
     }
-    const tooltipX = posLeft + timelineScroll.offsetLeft;
-    const tooltipY = posTop + timelineScroll.offsetTop;
+    const tooltipX = posLeft + timelineWrapper.offsetLeft;
+    const tooltipY = posTop + timelineWrapper.offsetTop;
     tooltip.innerHTML = "";
     tooltip.appendChild(tooltipText);
     tooltip.style.cssText = `left:${tooltipX}px; top:${tooltipY}px; display: block;`;
@@ -474,7 +474,7 @@ function showTooltipWithText(
  * +-TimelineView---------+		The timelineView is the positioning parent
  * | +-Tooltip-+          |		The tooltip is absolutely positioned
  * | +---------+          |
- * | +-TimelineScroll--+  |		The timelineScroller is staticly positioned
+ * | +-timelineWrapper--+  |		The timelineWrapperer is staticly positioned
  * | | +-Timeline-+    |  |		The timeline is statisly positioned
  * | | +----------+    |  |
  * | +-----------------+  |
@@ -575,13 +575,13 @@ function handleScroll(evt: WheelEvent) {
   }
 }
 
-function onTimelineScroll() {
+function onTimelineWrapper() {
   showTooltip(lastMouseX, lastMouseY);
 }
 
 function onInitTimeline(evt: Event) {
   const canvas = document.getElementById("timeline") as HTMLCanvasElement,
-    timelineScroll = document.getElementById("timelineScroll");
+    timelineWrapper = document.getElementById("timelineWrapper");
   tooltip = document.getElementById("tooltip") as HTMLDivElement;
 
   canvas?.addEventListener("mouseout", onLeaveCanvas);
@@ -590,7 +590,7 @@ function onInitTimeline(evt: Event) {
   canvas?.addEventListener("mouseup", handleMouseUp);
   canvas?.addEventListener("mousemove", handleMouseMove, { passive: true });
   canvas?.addEventListener("click", onClickCanvas);
-  timelineScroll?.addEventListener("scroll", onTimelineScroll);
+  timelineWrapper?.addEventListener("scroll", onTimelineWrapper);
 
   // document seem to get all the events (regardless of which element we're over)
   document.addEventListener("mousemove", onMouseMove);

--- a/log-viewer/modules/Timeline.ts
+++ b/log-viewer/modules/Timeline.ts
@@ -43,7 +43,7 @@ const scaleY = -15,
 
 let tooltip: HTMLDivElement;
 let realHeight = 0;
-let centerOffset = 0;
+let horizontalOffset = 0;
 let verticalOffset = 0;
 let initialZoom = 0;
 let container: HTMLDivElement;
@@ -110,7 +110,7 @@ function drawScale(ctx: CanvasRenderingContext2D) {
   const nsWidth = nanoSeconds * scaleX;
 
   // Find the start time based on the LHS of visible area
-  const startTimeInNs = centerOffset / scaleX;
+  const startTimeInNs = horizontalOffset / scaleX;
   // Find the end time based on the start + width of visible area.
   const endTimeInNs = startTimeInNs + displayWidth / scaleX;
 
@@ -120,7 +120,7 @@ function drawScale(ctx: CanvasRenderingContext2D) {
   ctx.fillStyle = "#F88962";
   ctx.beginPath();
   for (let i = startTimeInS; i <= endTimeInS; i++) {
-    const xPos = ~~(0.5 + nsWidth * i - centerOffset);
+    const xPos = ~~(0.5 + nsWidth * i - horizontalOffset);
     ctx.moveTo(xPos, -displayHeight);
     ctx.lineTo(xPos, 0);
 
@@ -155,7 +155,7 @@ function drawScale(ctx: CanvasRenderingContext2D) {
     i = i + closestIncrement;
     const wholeNumber = i % 1000000 === 0;
     if (!wholeNumber && i >= startTimeInMicroSecs) {
-      const xPos = ~~(0.5 + microSecWidth * i - centerOffset);
+      const xPos = ~~(0.5 + microSecWidth * i - horizontalOffset);
       ctx.moveTo(xPos, -displayHeight);
       ctx.lineTo(xPos, 0);
       ctx.fillText(i / 1000 + " ms", xPos + 2, textHeight);
@@ -187,8 +187,8 @@ function drawNodes(
 
       if (width >= 0.25) {
         ctx.fillStyle = tl.fillColor;
-        ctx.fillRect(x - centerOffset, y - verticalOffset, width, scaleY);
-        ctx.strokeRect(x - centerOffset, y - verticalOffset, width, scaleY);
+        ctx.fillRect(x - horizontalOffset, y - verticalOffset, width, scaleY);
+        ctx.strokeRect(x - horizontalOffset, y - verticalOffset, width, scaleY);
       }
     }
 
@@ -221,7 +221,7 @@ function drawTruncation(ctx: CanvasRenderingContext2D) {
       ctx.fillStyle = thisEntry[2];
     }
     ctx.fillRect(
-      startTime * scaleX - centerOffset,
+      startTime * scaleX - horizontalOffset,
       -displayHeight,
       endTime - startTime * scaleX,
       displayHeight
@@ -238,7 +238,7 @@ function calculateSizes(canvas: HTMLCanvasElement) {
 function resetView() {
   resize();
   realHeight = -scaleY * maxY;
-  centerOffset = 0;
+  horizontalOffset = 0;
   verticalOffset = 0;
 }
 
@@ -320,7 +320,7 @@ function findByPosition(
 
   if (node.duration) {
     // we can only test nodes with a duration
-    const starttime = node.timestamp * scaleX - centerOffset;
+    const starttime = node.timestamp * scaleX - horizontalOffset;
     const width = node.duration * scaleX;
     const endtime = starttime + width;
 
@@ -431,8 +431,8 @@ function findTruncatedTooltip(x: number): HTMLDivElement | null {
       endTime = nextEntry[1] ?? maxX;
 
     if (
-      x >= startTime * scaleX - centerOffset &&
-      x <= endTime * scaleX - centerOffset
+      x >= startTime * scaleX - horizontalOffset &&
+      x <= endTime * scaleX - horizontalOffset
     ) {
       const toolTip = document.createElement("div");
       toolTip.textContent = thisEntry[0];
@@ -534,7 +534,10 @@ function handleMouseMove(evt: MouseEvent) {
     tooltip.style.display = "none";
     const { movementY, movementX } = evt;
     const maxWidth = scaleX * maxX - displayWidth;
-    centerOffset = Math.max(0, Math.min(maxWidth, centerOffset - movementX));
+    horizontalOffset = Math.max(
+      0,
+      Math.min(maxWidth, horizontalOffset - movementX)
+    );
 
     const realHeight = maxY * -scaleY;
     const maxVertOffset = ~~(realHeight - displayHeight + displayHeight / 4);
@@ -561,14 +564,17 @@ function handleScroll(evt: WheelEvent) {
     if (zoomDelta !== 0) {
       scaleX = scaleX - zoomDelta;
       if (scaleX !== oldZoom) {
-        const timePosBefore = (lastMouseX + centerOffset) / oldZoom;
+        const timePosBefore = (lastMouseX + horizontalOffset) / oldZoom;
         const newOffset = timePosBefore * scaleX - lastMouseX;
         const maxWidth = scaleX * maxX - displayWidth;
-        centerOffset = Math.max(0, Math.min(maxWidth, newOffset));
+        horizontalOffset = Math.max(0, Math.min(maxWidth, newOffset));
       }
     } else {
       const maxWidth = scaleX * maxX - displayWidth;
-      centerOffset = Math.max(0, Math.min(maxWidth, centerOffset + deltaX));
+      horizontalOffset = Math.max(
+        0,
+        Math.min(maxWidth, horizontalOffset + deltaX)
+      );
     }
   }
 }

--- a/log-viewer/modules/Timeline.ts
+++ b/log-viewer/modules/Timeline.ts
@@ -304,10 +304,6 @@ function renderTimelineKey() {
   }
 }
 
-function onShrinkToFit(evt: any) {
-  resetView();
-}
-
 function findByPosition(
   node: LogLine,
   depth: number,
@@ -585,11 +581,9 @@ function onTimelineScroll() {
 
 function onInitTimeline(evt: Event) {
   const canvas = document.getElementById("timeline") as HTMLCanvasElement,
-    timelineScroll = document.getElementById("timelineScroll"),
-    shrinkToFit = document.getElementById("shrinkToFit");
+    timelineScroll = document.getElementById("timelineScroll");
   tooltip = document.getElementById("tooltip") as HTMLDivElement;
 
-  shrinkToFit?.addEventListener("click", onShrinkToFit);
   canvas?.addEventListener("mouseout", onLeaveCanvas);
   canvas?.addEventListener("wheel", handleScroll, { passive: true });
   canvas?.addEventListener("mousedown", handleMouseDown);

--- a/log-viewer/modules/Timeline.ts
+++ b/log-viewer/modules/Timeline.ts
@@ -359,7 +359,7 @@ function findTimelineTooltip(x: number, depth: number): HTMLDivElement | null {
         toolTip.appendChild(brElem.cloneNode());
         toolTip.appendChild(
           document.createTextNode(
-            "duration: " + formatDuration(target.duration)
+            `duration: ${formatDuration(target.duration)}`
           )
         );
         if (target.cpuType === "free") {
@@ -367,7 +367,7 @@ function findTimelineTooltip(x: number, depth: number): HTMLDivElement | null {
         } else {
           toolTip.appendChild(
             document.createTextNode(
-              " (netDuration: " + formatDuration(target.netDuration) + ")"
+              ` (self ${formatDuration(target.netDuration)})`
             )
           );
         }

--- a/log-viewer/modules/TreeView.ts
+++ b/log-viewer/modules/TreeView.ts
@@ -167,7 +167,7 @@ function describeMethod(node: LogLine) {
     const nodeValue = node.value ? ` = ${node.value}` : "";
     const timeTaken = node.truncated
       ? "TRUNCATED"
-      : `${formatDuration(node.duration || 0)} (${formatDuration(
+      : `${formatDuration(node.duration || 0)} (self ${formatDuration(
           node.netDuration || 0
         )})`;
     const lineNumber = node.lineNumber ? `, line: ${node.lineNumber}` : "";

--- a/log-viewer/out/index.html
+++ b/log-viewer/out/index.html
@@ -36,10 +36,6 @@
 		</div>
 		<div class="tabber">
 			<div id="timelineView" class="tabItem selected">
-				<div class="buttonContainer">
-					<label for="shrinkToFit">Shrink-to-fit: </label>
-					<input id="shrinkToFit" type="checkbox" checked>
-				</div>
 				<div id="tooltip"></div>
 				<div id="timelineScroll">
 					<canvas id='timeline'></canvas>

--- a/log-viewer/out/index.html
+++ b/log-viewer/out/index.html
@@ -37,7 +37,7 @@
 		<div class="tabber">
 			<div id="timelineView" class="tabItem selected">
 				<div id="tooltip"></div>
-				<div id="timelineScroll">
+				<div id="timelineWrapper">
 					<canvas id='timeline'></canvas>
 				</div>
 				<div id="timelineKey"></div>

--- a/log-viewer/out/index.html
+++ b/log-viewer/out/index.html
@@ -42,7 +42,7 @@
 				</div>
 				<div id="tooltip"></div>
 				<div id="timelineScroll">
-					<canvas id='timeline' width="10000" height="4000"></canvas>
+					<canvas id='timeline'></canvas>
 				</div>
 				<div id="timelineKey"></div>
 			</div>

--- a/log-viewer/resources/css/TimelineView.css
+++ b/log-viewer/resources/css/TimelineView.css
@@ -19,7 +19,7 @@
 #timelineKey {
 	margin-top: 5px;
 }
-#timelineScroll {
+#timelineWrapper {
 	flex: 1;
 	overflow: hidden;
 }

--- a/log-viewer/resources/css/TimelineView.css
+++ b/log-viewer/resources/css/TimelineView.css
@@ -11,11 +11,8 @@
 	word-break: break-word;
 	max-width: 1000px;
 }
-#timelineScroll {
-	z-index: 0;
-	overflow: auto;
-}
 #timeline {
+	background-color: var(--vscode-editor-background);
 	z-index: 0;
 }
 #timelineKey {

--- a/log-viewer/resources/css/TimelineView.css
+++ b/log-viewer/resources/css/TimelineView.css
@@ -1,5 +1,6 @@
 #timelineView {
 	position: relative;
+	height: 75%;
 }
 #tooltip {
 	display: none;
@@ -17,6 +18,10 @@
 }
 #timelineKey {
 	margin-top: 5px;
+}
+#timelineScroll {
+	flex: 1;
+	overflow: hidden;
 }
 #timelineKey .keyEntry {
 	display: inline-block;

--- a/log-viewer/resources/css/TreeView.css
+++ b/log-viewer/resources/css/TreeView.css
@@ -40,8 +40,8 @@
 	margin-top: 2px;
 	white-space: pre;
 	/* This is emulate the effect of hanging indent on text */
-	padding-left: 1em ;
-	text-indent: -1em ;
+	padding-left: 1em;
+	text-indent: -1em;
 }
 .detail {
 }


### PR DESCRIPTION
**Zoom on timeline**
  - zoom to an accuracy of 0.001ms, time markers are shown with a ms time value and white line e.g 9600.001 ms
  - scroll up and down on the mouse to zoom in and out
  - zoom is based on position of mouse pointer, ensuring that position is kept on screen when zoomed in or out
  - scroll left and right on the mouse to move the time line left are right, when zoomed
  - click the mouse down and drag to move the timeline around both in the x and y direction, when zoomed
  
resolves: #33
  