### PR TITLE
fix: tooltip to always stay on screen

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,28 +2,27 @@ name: Build
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Node
-      uses: actions/setup-node@v2-beta
-      with:
-        node-version: '12'
-    - name: Install vsce
-      run: npm install --global vsce
-    - name: Dependencies
-      run: |
-        cd lana
-        npm ci
-    - name: Build
-      run: | 
-        cd lana
-        vsce package
+      - uses: actions/checkout@v2
+      - name: Set up Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+      - name: Install vsce
+        run: npm install --global vsce
+      - name: Dependencies
+        run: |
+          cd lana
+          npm ci
+      - name: Build
+        run: |
+          cd lana
+          vsce package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,26 +6,25 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Node
-      uses: actions/setup-node@v2-beta
-      with:
-        node-version: '12'
-    - name: Install vsce
-      run: npm install --global vsce
-    - name: Dependencies
-      run: |
-        cd lana
-        npm ci
-    - name: Build
-      run: | 
-        cd lana
-        vsce package
-    - name: Publish to Marketplace
-      run: |
-       cd lana
-       vsce publish -p ${{ secrets.VSCE_TOKEN }} --packagePath lana-${{ github.event.release.tag_name }}.vsix
+      - uses: actions/checkout@v2
+      - name: Set up Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+      - name: Install vsce
+        run: npm install --global vsce
+      - name: Dependencies
+        run: |
+          cd lana
+          npm ci
+      - name: Build
+        run: |
+          cd lana
+          vsce package
+      - name: Publish to Marketplace
+        run: |
+          cd lana
+          vsce publish -p ${{ secrets.VSCE_TOKEN }} --packagePath lana-${{ github.event.release.tag_name }}.vsix

--- a/log-viewer/modules/Timeline.ts
+++ b/log-viewer/modules/Timeline.ts
@@ -418,10 +418,13 @@ function showTooltipWithText(
         posTop = -100;
       }
     }
+    posLeft = posLeft + timelineScroll.offsetLeft;
+    posTop = posTop + timelineScroll.offsetTop;
+
     tooltip.innerHTML = "";
     tooltip.appendChild(tooltipText);
-    tooltip.style.left = posLeft + timelineScroll.offsetLeft + "px";
-    tooltip.style.top = posTop + timelineScroll.offsetTop + "px";
+    tooltip.style.left = posLeft + "px";
+    tooltip.style.top = posTop + "px";
     tooltip.style.display = "block";
   } else {
     tooltip.style.display = "none";

--- a/log-viewer/resources/css/TimelineView.css
+++ b/log-viewer/resources/css/TimelineView.css
@@ -8,7 +8,6 @@
 	padding: 5px;
 	background-color: var(--vscode-editor-background);
 	color: var(--vscode-editor-foreground);
-	word-break: break-word;
 	max-width: 1000px;
 }
 #timelineScroll {


### PR DESCRIPTION
Add the right edge of the screen the tooltip would shrink to be unreadable.
It will now be pushed left instead and retain size.

This was not a regression and was introduced in develop after v1.3.4 was released.
So not adding it to changelog, unless there is an objection.

fixes: #71 

![image](https://user-images.githubusercontent.com/4013877/141971869-5707de3e-8010-4283-a146-486ed69c5314.png)
