### PR TITLE
feat: calltree scroll until content stuck to top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Call tree to show text for all log lines and not just time taken ([#42][#42])
 - Faster log loading due to a change in how the JavaScript is loaded on the page ([#11][#11])
 - Faster log parsing and timeline rendering ([#63][#63])
-- Scroll on the calltree to allow scrolling content to toof screen instead of only the bottom ([#73][#73])
+- Scroll on the calltree to allow scrolling content to top of screen instead of only the bottom ([#73][#73])
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Call tree to show text for all log lines and not just time taken ([#42][#42])
 - Faster log loading due to a change in how the JavaScript is loaded on the page ([#11][#11])
 - Faster log parsing and timeline rendering ([#63][#63])
+- Scroll on the calltree to allow scrolling content to toof screen instead of only the bottom ([#73][#73])
 
 ### Fixed
 
@@ -82,3 +83,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#50]: https://github.com/financialforcedev/debug-log-analyzer/issues/50
 [#52]: https://github.com/financialforcedev/debug-log-analyzer/issues/52
 [#63]: https://github.com/financialforcedev/debug-log-analyzer/issues/63
+[#73]: https://github.com/financialforcedev/debug-log-analyzer/issues/73

--- a/log-viewer/modules/TreeView.ts
+++ b/log-viewer/modules/TreeView.ts
@@ -304,7 +304,7 @@ function createChildNodes(children: LogLine[], timeStamps: number[]) {
 }
 
 function renderTree() {
-  const treeContainer = document.getElementById("tree");
+  const treeContainer = document.getElementById("tree") as HTMLElement;
   if (treeContainer) {
     treeContainer.addEventListener("click", onExpandCollapse);
     treeContainer.addEventListener("click", goToFile);
@@ -313,6 +313,9 @@ function renderTree() {
     treeContainer.innerHTML = "";
     if (callTreeNode) {
       treeContainer.appendChild(callTreeNode);
+      const spacer = divElem.cloneNode() as HTMLDivElement;
+      spacer.style.height = `78vh`;
+      treeContainer.appendChild(spacer);
       showHideDetails();
     }
   }


### PR DESCRIPTION
This is not a perfect solution as the content will not be scrolled to top in all cases.
If the screen size is small or the view size has been reduced this will not work correctly.

resolves: #73 