### PR TITLE
fix: align all callstack with first line in database view

### DIFF
--- a/log-viewer/modules/components/CallStack.ts
+++ b/log-viewer/modules/components/CallStack.ts
@@ -25,6 +25,7 @@ class CallStack extends LitElement {
       .stackEntry {
         cursor: pointer;
         display: block;
+        padding-left: 1em;
       }
     `;
   }

--- a/log-viewer/modules/components/DatabaseRow.ts
+++ b/log-viewer/modules/components/DatabaseRow.ts
@@ -38,8 +38,10 @@ class DatabaseRow extends LitElement {
     if (soqlMap && dmlMap) {
       let entry = soqlMap.get(this.key) || dmlMap.get(this.key);
       if (entry) {
-        const detail = this.key.substr(this.key.indexOf(" ") + 1);
-        const stacks = entry.stacks.map((stack) => html`<call-stack stack=${stack} />`);
+        const detail = this.key.substring(this.key.indexOf(" ") + 1);
+        const stacks = entry.stacks.map(
+          (stack) => html`<call-stack stack=${stack} />`
+        );
         return html`
           <div class="dbEntry">
             <span class="dbCount">Count: ${entry.count}</span>


### PR DESCRIPTION
All methods after the first line were indented to the left.
The have been shifted to the right so they align with the first line in the callstack.

I have not created an entry in the changelog since this was a fix for a new feature introduced in develop after v1.3.4 release.

![image](https://user-images.githubusercontent.com/81575432/142039832-03cece9b-d7b0-4349-984b-26d0e55b40ca.png)

fixes: #69