### PR TITLE
feat: add pb and flow names in timeline + calltree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Faster log loading due to a change in how the JavaScript is loaded on the page ([#11][#11])
 - Faster log parsing and timeline rendering ([#63][#63])
 - Scroll on the calltree to allow scrolling content to top of screen instead of only the bottom ([#73][#73])
+- `FLOW_START_INTERVIEWS` log lines on the calltree and timeline will show either the Process Builder or Flow name after the chunk number ([#68][#68])
 
 ### Fixed
 
@@ -83,4 +84,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#50]: https://github.com/financialforcedev/debug-log-analyzer/issues/50
 [#52]: https://github.com/financialforcedev/debug-log-analyzer/issues/52
 [#63]: https://github.com/financialforcedev/debug-log-analyzer/issues/63
+[#68]: https://github.com/financialforcedev/debug-log-analyzer/issues/68
 [#73]: https://github.com/financialforcedev/debug-log-analyzer/issues/73

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,17 +26,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Load log shows loading feedback whilst waiting for logs to be retrieved ([#18][#18])
 - Open an empty log view whilst waiting for selected log to be downloaded, parsed and rendered ([#18][#18])
 - Log will be loaded from disk if previously downloaded ([#18][#18])
-- Renamed the `Log: Show Log Analysis` command to `Log: Show Apex Log Analysis` [#48][#48]
+- Renamed the `Log: Show Log Analysis` command to `Log: Show Apex Log Analysis` ([#48][#48])
   - For consistency with the `Log: Load Apex Log For Analysis` command
 - Block text on call tree displayed on new lines rather than one line separated by a | character ([#50][#50])
-- Call tree to show text for all log lines and not just time taken ([#42][#42])
+- Call tree shows text for all log lines and not just time taken ([#42][#42])
 - Faster log loading due to a change in how the JavaScript is loaded on the page ([#11][#11])
 - Faster log parsing and timeline rendering ([#63][#63])
 - Scroll on the calltree to allow scrolling content to top of screen instead of only the bottom ([#73][#73])
 
 ### Fixed
 
-- Hide details, hide system calls and hide formulas on the call tree to work again [#45][#45]
+- Hide details, hide system calls and hide formulas on the call tree to work again ([#45][#45])
 
 ### Removed
 

--- a/lana/package.json
+++ b/lana/package.json
@@ -7,7 +7,9 @@
 		"salesforce",
 		"apex",
 		"apexlog",
-		"debuglog"
+		"debuglog",
+		"debug",
+		"log"
 	],
 	"main": "out/Main.js",
 	"icon": "logo.png",

--- a/log-viewer/modules/Timeline.ts
+++ b/log-viewer/modules/Timeline.ts
@@ -501,8 +501,8 @@ function showTooltipWithText(
     const tooltipX = posLeft + timelineWrapper.offsetLeft;
     const tooltipY = posTop + timelineWrapper.offsetTop;
     tooltip.innerHTML = "";
-    tooltip.appendChild(tooltipText);
     tooltip.style.cssText = `left:${tooltipX}px; top:${tooltipY}px; display: block;`;
+    tooltip.appendChild(tooltipText);
   } else {
     tooltip.style.display = "none";
   }

--- a/log-viewer/modules/parsers/LineParser.ts
+++ b/log-viewer/modules/parsers/LineParser.ts
@@ -1,9 +1,6 @@
 /*
  * Copyright (c) 2020 FinancialForce.com, inc. All rights reserved.
  */
-import { threadId } from "worker_threads";
-import { decodeEntities } from "../Browser.js";
-
 const typePattern = /^[A-Z_]*$/,
   truncateColor: Map<string, string> = new Map([
     ["error", "rgba(255, 128, 128, 0.2)"],
@@ -688,6 +685,16 @@ class FlowStartInterviewsBeginLine extends LogLine {
     super(parts);
     this.text = "FLOW_START_INTERVIEWS : " + parts[2];
   }
+
+  onEnd(end: LogLine) {
+    if (this.children) {
+      let interviewBegin = this.children[0];
+      if (interviewBegin.displayType === "block" && interviewBegin.children) {
+        interviewBegin = interviewBegin.children[0];
+      }
+      this.text += " - " + interviewBegin.text;
+    }
+  }
 }
 
 class FlowStartInterviewsEndLine extends LogLine {
@@ -1235,7 +1242,7 @@ export default async function parseLog(log: string) {
   rawLines.pop();
   rawLines.shift();
 
-  // reset global variables to be captured durung parsing
+  // reset global variables to be captured during parsing
   logLines = [];
   truncated = [];
   reasons = new Set<string>();

--- a/log-viewer/modules/parsers/TreeParser.ts
+++ b/log-viewer/modules/parsers/TreeParser.ts
@@ -68,7 +68,6 @@ function getMethod(lineIter: LineIterator, method: LogLine) {
         discontinuity = true; // start unwinding stack
       }
       if (line.isExit) {
-        endMethod(method, line, lineIter);
         break;
       }
 
@@ -92,6 +91,10 @@ function getMethod(lineIter: LineIterator, method: LogLine) {
 
     if (lines.length) {
       method.addBlock(lines);
+    }
+
+    if (line?.isExit) {
+      endMethod(method, line, lineIter);
     }
   }
   recalculateDurations(method);


### PR DESCRIPTION
- `FLOW_START_INTERVIEWS` log lines on the calltree and timeline will show either the Process Builder or Flow name after the chunk number 

**Process builders**
Calltree
![image](https://user-images.githubusercontent.com/4013877/142656923-4a5fec51-3bcd-4fb3-b757-9ea4620cef49.png)

Timeline
![image](https://user-images.githubusercontent.com/4013877/142657131-4d17e11d-fdb6-48fd-a92d-a4558699f029.png)


**Flow**
Calltree
![image](https://user-images.githubusercontent.com/4013877/142657029-a39a4c48-0bb4-4fe1-b098-d39d07b7748f.png)

Timeline
![image](https://user-images.githubusercontent.com/4013877/142657209-53b6bcf9-3192-45fb-b28b-66b78f711e0b.png)


resolves #68 