### PR TITLE
bug: incorrect end time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Totaltime on status bar and analysis tab not always correct ([#95][#95])
+  - Now uses the time between `EXECUTION_STARTED` and `EXECUTION_FINISED` as the total time.
+
 ## [1.4.1] - January 2022
 
 ### Changed
@@ -101,3 +108,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#68]: https://github.com/financialforcedev/debug-log-analyzer/issues/68
 [#73]: https://github.com/financialforcedev/debug-log-analyzer/issues/73
 [#81]: https://github.com/financialforcedev/debug-log-analyzer/issues/81
+[#95]: https://github.com/financialforcedev/debug-log-analyzer/issues/95

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Totaltime on status bar and analysis tab not always correct ([#95][#95])
+- Totaltime on status bar and analysis tab ([#95][#95])
   - Now uses the time between `EXECUTION_STARTED` and `EXECUTION_FINISED` as the total time.
 
 ## [1.4.1] - January 2022

--- a/log-viewer/modules/Analysis.ts
+++ b/log-viewer/modules/Analysis.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2020 FinancialForce.com, inc. All rights reserved.
  */
 import formatDuration, { highlightText } from "./Util";
-import { totalDuration } from "./parsers/LineParser";
+import { totalDuration } from "./Timeline";
 import { RootNode } from "./parsers/TreeParser";
 import { LogLine } from "./parsers/LineParser";
 

--- a/log-viewer/modules/Main.ts
+++ b/log-viewer/modules/Main.ts
@@ -185,14 +185,13 @@ function timer(text: string) {
 
 async function renderLogSettings(logSettings: [string, string][]) {
   const holder = document.getElementById("logSettings");
-
-  if (holder) {
-  holder.innerHTML = "";
+  if (!holder) {
+    return;
   }
 
-  for (const logSetting of logSettings) {
-    const [name, level] = logSetting;
-
+  holder.innerHTML = "";
+  const fragment = document.createDocumentFragment();
+  for (const [name, level] of logSettings) {
     if (level !== "NONE") {
       const setting = document.createElement("div"),
         title = document.createElement("span"),
@@ -205,9 +204,11 @@ async function renderLogSettings(logSettings: [string, string][]) {
       setting.className = "setting";
       setting.appendChild(title);
       setting.appendChild(value);
-      holder?.appendChild(setting);
+      fragment.appendChild(setting);
     }
   }
+
+  holder.appendChild(fragment);
 }
 
 async function displayLog(log: string, name: string, path: string) {

--- a/log-viewer/modules/Main.ts
+++ b/log-viewer/modules/Main.ts
@@ -9,7 +9,11 @@ import parseLog, {
 } from "./parsers/LineParser";
 import { getRootMethod } from "./parsers/TreeParser";
 import renderTreeView from "./TreeView";
-import renderTimeline, { maxX, setColors, renderTimelineKey } from "./Timeline";
+import renderTimeline, {
+  totalDuration,
+  setColors,
+  renderTimelineKey,
+} from "./Timeline";
 import analyseMethods, { renderAnalysis } from "./Analysis";
 import { DatabaseAccess, renderDb } from "./Database";
 import { setNamespaces } from "./NamespaceExtrator";
@@ -46,7 +50,9 @@ async function setStatus(
     nameLink = document.createElement("a"),
     statusSpan = document.createElement("span"),
     sizeText = logSize ? (logSize / 1000000).toFixed(2) + " MB" : "",
-    elapsedText = maxX ? (maxX / 1000000000).toFixed(3) + " Sec" : "",
+    elapsedText = totalDuration
+      ? (totalDuration / 1000000000).toFixed(3) + " Sec"
+      : "",
     infoSep = sizeText && elapsedText ? ", " : "",
     infoText =
       sizeText || elapsedText
@@ -181,7 +187,7 @@ async function renderLogSettings(logSettings: [string, string][]) {
   const holder = document.getElementById("logSettings");
 
   if (holder) {
-    holder.innerHTML = "";
+  holder.innerHTML = "";
   }
 
   for (const logSetting of logSettings) {

--- a/log-viewer/modules/Timeline.ts
+++ b/log-viewer/modules/Timeline.ts
@@ -3,9 +3,8 @@
  */
 import { showTreeNode } from "./TreeView";
 import formatDuration from "./Util";
-import { truncated } from "./parsers/LineParser";
+import { LogLine, truncated } from "./parsers/LineParser";
 import { RootNode } from "./parsers/TreeParser";
-import { LogLine } from "./parsers/LineParser";
 
 const scaleY = -15,
   strokeColor = "#B0B0B0",

--- a/log-viewer/modules/Timeline.ts
+++ b/log-viewer/modules/Timeline.ts
@@ -52,7 +52,7 @@ let ctx: CanvasRenderingContext2D | null;
 
 let scaleX: number,
   scaleFont: string,
-  maxX: number,
+  totalDuration: number,
   maxY: number,
   displayHeight: number,
   displayWidth: number,
@@ -60,24 +60,12 @@ let scaleX: number,
   lastMouseX: number,
   lastMouseY: number;
 
-function getMaxWidth(node: LogLine) {
-  if (node.exitStamp) {
-    return node.exitStamp;
-  }
-  if (!node.children) {
+function getMaxWidth(rootNode: LogLine) {
+  if (!rootNode.children) {
     return 0;
   }
-
-  let maxX = node.timestamp || 0;
-  const len = node.children.length - 1;
-  for (let c = len; c >= 0; --c) {
-    const max = getMaxWidth(node.children[c]);
-    if (max && max > maxX) {
-      maxX = max;
-    }
-  }
-
-  return maxX;
+  // First child of the root node should be "EXECUTION_STARTED"
+  return rootNode.children[0].exitStamp || 0;
 }
 
 function getMaxDepth(node: LogLine, depth = 0) {
@@ -255,7 +243,7 @@ function drawTruncation(ctx: CanvasRenderingContext2D) {
     const thisEntry = truncated[i++],
       nextEntry = truncated[i] ?? [],
       startTime = thisEntry[1],
-      endTime = nextEntry[1] ?? maxX;
+      endTime = nextEntry[1] ?? totalDuration;
 
     if (thisEntry[2]) {
       ctx.fillStyle = thisEntry[2];
@@ -271,7 +259,7 @@ function drawTruncation(ctx: CanvasRenderingContext2D) {
 }
 
 function calculateSizes(canvas: HTMLCanvasElement) {
-  maxX = getMaxWidth(timelineRoot); // maximum display value in nano-seconds
+  totalDuration = getMaxWidth(timelineRoot); // maximum display value in nano-seconds
   maxY = getMaxDepth(timelineRoot); // maximum nested call depth
   resetView();
 }
@@ -288,8 +276,8 @@ function resize() {
   displayHeight = container.clientHeight;
   canvas.width = displayWidth;
   canvas.height = displayHeight;
-  initialZoom = displayWidth / maxX;
-  scaleX = displayWidth / maxX;
+  initialZoom = displayWidth / totalDuration;
+  scaleX = displayWidth / totalDuration;
   resizeFont();
 }
 function resizeFont() {
@@ -319,6 +307,7 @@ export function setColors(timelineColors: any) {
   }
 }
 
+// todo: stop clearing on every iteration + only do it if a change event occurs (e.g we zoom, or scroll or resize)
 function drawTimeLine() {
   if (ctx) {
     resizeFont();
@@ -477,7 +466,7 @@ function findTruncatedTooltip(x: number): HTMLDivElement | null {
     const thisEntry = truncated[i++],
       nextEntry = truncated[i] ?? [],
       startTime = thisEntry[1],
-      endTime = nextEntry[1] ?? maxX;
+      endTime = nextEntry[1] ?? totalDuration;
 
     if (
       x >= startTime * scaleX - horizontalOffset &&
@@ -582,7 +571,7 @@ function handleMouseMove(evt: MouseEvent) {
   if (dragging) {
     tooltip.style.display = "none";
     const { movementY, movementX } = evt;
-    const maxWidth = scaleX * maxX - displayWidth;
+    const maxWidth = scaleX * totalDuration - displayWidth;
     horizontalOffset = Math.max(
       0,
       Math.min(maxWidth, horizontalOffset - movementX)
@@ -615,11 +604,11 @@ function handleScroll(evt: WheelEvent) {
       if (scaleX !== oldZoom) {
         const timePosBefore = (lastMouseX + horizontalOffset) / oldZoom;
         const newOffset = timePosBefore * scaleX - lastMouseX;
-        const maxWidth = scaleX * maxX - displayWidth;
+        const maxWidth = scaleX * totalDuration - displayWidth;
         horizontalOffset = Math.max(0, Math.min(maxWidth, newOffset));
       }
     } else {
-      const maxWidth = scaleX * maxX - displayWidth;
+      const maxWidth = scaleX * totalDuration - displayWidth;
       horizontalOffset = Math.max(
         0,
         Math.min(maxWidth, horizontalOffset + deltaX)
@@ -651,4 +640,4 @@ function onInitTimeline(evt: Event) {
 
 window.addEventListener("DOMContentLoaded", onInitTimeline);
 window.addEventListener("resize", resize);
-export { maxX };
+export { totalDuration };

--- a/log-viewer/modules/__tests__/LineParser.test.ts
+++ b/log-viewer/modules/__tests__/LineParser.test.ts
@@ -13,7 +13,6 @@ import {
   CodeUnitStartedLine,
   CodeUnitFinishedLine,
   truncated,
-  totalDuration,
   cpuUsed,
   ExecutionStartedLine,
   ExecutionFinishedLine,
@@ -170,16 +169,6 @@ describe("parseLog tests", () => {
     expect(truncated[0][0]).toBe(
       "FATAL ERROR! cause=System.LimitException: c2g:Too many SOQL queries: 101"
     );
-  });
-  it("Should capture totalDuration", async () => {
-    const log =
-      "09:18:22.6 (100)|EXECUTION_STARTED\n\n" +
-      "15:20:52.222 (200)|METHOD_ENTRY|[185]|01p4J00000FpS6t|CODAUnitOfWork.getNextIdInternal()\n" +
-      "15:20:52.222 (1000)|METHOD_EXIT|[185]|01p4J00000FpS6t|CODAUnitOfWork.getNextIdInternal()\n" +
-      "09:19:13.82 (2000)|EXECUTION_FINISHED\n";
-
-    parseLog(log);
-    expect(totalDuration).toBe(1900);
   });
   it("Methods should have line-numbers", async () => {
     const log =

--- a/log-viewer/modules/parsers/LineParser.ts
+++ b/log-viewer/modules/parsers/LineParser.ts
@@ -88,7 +88,6 @@ export class BlockLines extends LogLine {
 }
 
 let logLines: LogLine[] = [],
-  totalDuration: number = 0,
   truncated: [string, number, string | undefined][],
   reasons: Set<string> = new Set<string>(),
   cpuUsed: number = 0;
@@ -1950,7 +1949,10 @@ const lineTypeMap = new Map<string, new (parts: string[]) => LogLine>([
   ["XDS_RESPONSE_ERROR", XDSResponseErrorLine],
 ]);
 
-export function parseLine(line: string, lastEntry: LogLine | null): LogLine | null {
+export function parseLine(
+  line: string,
+  lastEntry: LogLine | null
+): LogLine | null {
   const parts = line.split("|"),
     type = parts[1],
     metaCtor = lineTypeMap.get(type);
@@ -1967,7 +1969,8 @@ export function parseLine(line: string, lastEntry: LogLine | null): LogLine | nu
       // wrapped text from the previous entry?
       lastEntry.text += ` | ${line}`;
     } else if (type) {
-      if (type !== 'DUMMY') /* Used by tests */
+      if (type !== "DUMMY")
+        /* Used by tests */
         console.warn(`Unknown log line: ${type}`);
     } else {
       if (lastEntry && line.startsWith("*** Skipped")) {
@@ -2009,10 +2012,6 @@ export default async function parseLog(log: string) {
     }
   }
 
-  const linLen = logLines.length;
-  const endTime = linLen ? logLines[logLines.length - 1].timestamp : 0;
-  const startTime = linLen ? logLines[0].timestamp : 0;
-  totalDuration = endTime - startTime;
   return logLines;
 }
 
@@ -2033,4 +2032,4 @@ export function getLogSettings(log: string): [string, string][] {
   });
 }
 
-export { logLines, totalDuration, truncated, cpuUsed };
+export { logLines, truncated, cpuUsed };


### PR DESCRIPTION
The total time on the status bar will be the time between `EXECUTION_STARTED` and `EXECUTION_FINISHED`.
Previously the end time would use the last valid line in the log which in some cases would be `CUMULATIVE_PROFILING` resulting in the total time being wrong on status and analysis tab as well as the timeline having some blank space at the end.

The total time is not taken from the `EXECUTION_STARTED` in the treeparser instead of the total duration in the lineparser.
The `EXECUTION_STARTED` node is the first child node of the root node.