### PR TITLE
Ability to filter call tree based on time taken

### DIFF
--- a/log-viewer/modules/TreeView.ts
+++ b/log-viewer/modules/TreeView.ts
@@ -244,6 +244,19 @@ function deriveOpenInfo(node: LogLine): OpenInfo | null {
 }
 
 function renderTreeNode(node: LogLine, timeStamps: number[]) {
+
+  const hideUnder = document.getElementById("hideUnder") as HTMLInputElement;
+  if(hideUnder?.checked) {
+    const timeInMS = document.getElementById("timeInMS") as HTMLInputElement;
+    let timeFilter = (timeInMS.value ? parseInt(timeInMS.value) : 0 ) * 1000000;
+
+    let timetaken = node.duration || 0;
+
+    if(node.text !== "Log Root" && timetaken < timeFilter) {
+      return undefined;
+    }
+  }
+
   const children = node.children ?? [];
 
   const mainNode = divElem.cloneNode() as HTMLDivElement;

--- a/log-viewer/out/index.html
+++ b/log-viewer/out/index.html
@@ -20,6 +20,9 @@
 				display: flex;
 				flex-direction: column;
 			}
+			#timeInMS {
+				width: 4rem;
+			}
 		</style>
 	</head>
 
@@ -53,6 +56,8 @@
 					<label for="hideSystem">Hide system calls</label>
 					<input id="hideFormula" class="filterCheckbox" type="checkbox">
 					<label for="hideFormula">Hide formulas</label>
+					<input id="hideUnder" class="filterCheckbox" type="checkbox">
+					<label for="hideUnder">Hide under <input id="timeInMS" type="number"> ms</label>
 				</div>
 				<div id="treeScroll">
 					<div id='tree'></div>


### PR DESCRIPTION
Firstly, I love this extension, made life so easy in debugging and backtracking the code without endless ctrl + f (like finding a needle in the haystack). 

This change adds a filter to the call tree providing an ability to hide details of methods, queries that take less time (in ms). This may help users identify the problem method/query faster by hiding unnecessary details. Users can control the time by specifying in a number input.

<img width="789" alt="Hide under" src="https://user-images.githubusercontent.com/8588422/154821279-ac1aee50-c897-48b3-8bbf-d22a6c7b398b.png">

resolves #112
 