### PR TITLE
bug: line parser split handle CRLF + LF line endings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,4 +20,4 @@ jobs:
         run: |
           cd log-viewer
           npm ci
-          npm run test
+          npm run test -- --runInBand

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,4 +20,4 @@ jobs:
         run: |
           cd log-viewer
           npm ci
-          npm run test -- --runInBand
+          npm run test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Timeline not displaying `VF_APEX_CALL_START` log events ([#97][#97])
 - Incorrect Totaltime on status bar and analysis tab ([#95][#95])
   - Now uses the time between `EXECUTION_STARTED` and `EXECUTION_FINISED` as the total time
+- Log parsing not handling both CRLF and LF line endings ([#108][#108])
 
 ## [1.4.1] - January 2022
 
@@ -115,3 +116,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#95]: https://github.com/financialforcedev/debug-log-analyzer/issues/95
 [#99]: https://github.com/financialforcedev/debug-log-analyzer/issues/97
 [#99]: https://github.com/financialforcedev/debug-log-analyzer/issues/99
+[#108]: https://github.com/financialforcedev/debug-log-analyzer/issues/108

--- a/log-viewer/jest.config.js
+++ b/log-viewer/jest.config.js
@@ -1,20 +1,21 @@
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
   preset: "ts-jest",
-  testEnvironment: "jsdom",
+  testEnvironment: "node",
   transform: {
     // transform files with ts-jest
     "^.+\\.(js|ts)$": "ts-jest",
   },
   transformIgnorePatterns: [
     // allow lit/@lit transformation
-    "node_modules/(?!\@?lit)"
+    "node_modules/(?!@?lit)",
   ],
   moduleNameMapper: {
     '^.+\\.(css|less)$': '<rootDir>/resources/css/stub.js'
   },
   globals: {
     "ts-jest": {
+      isolatedModules: true,
       tsconfig: {
         // allow js in typescript
         allowJs: true,
@@ -22,4 +23,3 @@ module.exports = {
     },
   },
 };
-

--- a/log-viewer/modules/__tests__/Analysis.test.ts
+++ b/log-viewer/modules/__tests__/Analysis.test.ts
@@ -1,8 +1,10 @@
+/**
+ * @jest-environment jsdom
+ */
 /*
  * Copyright (c) 2020 FinancialForce.com, inc. All rights reserved.
  */
 import analyseMethods, { Metric } from "../Analysis";
-import { DatabaseAccess } from "../Database";
 import parseLog from "../parsers/LineParser";
 import { getRootMethod } from "../parsers/TreeParser";
 

--- a/log-viewer/modules/__tests__/Database.test.ts
+++ b/log-viewer/modules/__tests__/Database.test.ts
@@ -1,7 +1,9 @@
+/**
+ * @jest-environment jsdom
+ */
 /*
  * Copyright (c) 2020 FinancialForce.com, inc. All rights reserved.
  */
-
 import { DatabaseAccess, DatabaseEntry } from "../Database";
 import parseLog from "../parsers/LineParser";
 import { getRootMethod } from "../parsers/TreeParser";

--- a/log-viewer/modules/__tests__/LineParser.test.ts
+++ b/log-viewer/modules/__tests__/LineParser.test.ts
@@ -103,6 +103,22 @@ describe("parseLog tests", () => {
     expect(logLines[3]).toBeInstanceOf(ExecutionFinishedLine);
   });
 
+  it("Should parse between EXECUTION_STARTED and EXECUTION_FINISHED for CRLF (\r\n)", async () => {
+    const log =
+      "09:18:22.6 (6508409)|USER_INFO|[EXTERNAL]|0050W000006W3LM|jwilson@57dev.financialforce.com|Greenwich Mean Time|GMT+01:00\r\n" +
+      "09:18:22.6 (6574780)|EXECUTION_STARTED\r\n" +
+      "09:18:22.6 (6586704)|CODE_UNIT_STARTED|[EXTERNAL]|066d0000002m8ij|pse.VFRemote: pse.SenchaTCController invoke(saveTimecard)\r\n" +
+      "09:19:13.82 (51592737891)|CODE_UNIT_FINISHED|pse.VFRemote: pse.SenchaTCController invoke(saveTimecard)\r\n" +
+      "09:19:13.82 (51595120059)|EXECUTION_FINISHED\r\n";
+
+    parseLog(log);
+    expect(logLines.length).toEqual(4);
+    expect(logLines[0]).toBeInstanceOf(ExecutionStartedLine);
+    expect(logLines[1]).toBeInstanceOf(CodeUnitStartedLine);
+    expect(logLines[2]).toBeInstanceOf(CodeUnitFinishedLine);
+    expect(logLines[3]).toBeInstanceOf(ExecutionFinishedLine);
+  });
+
   it("Should handle partial logs", async () => {
     const log =
       "09:18:22.6 (6574780)|EXECUTION_STARTED\n" +

--- a/log-viewer/modules/__tests__/TreeView.test.ts
+++ b/log-viewer/modules/__tests__/TreeView.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /*
  * Copyright (c) 2020 FinancialForce.com, inc. All rights reserved.
  */

--- a/log-viewer/modules/__tests__/Util.test.ts
+++ b/log-viewer/modules/__tests__/Util.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /*
  * Copyright (c) 2020 FinancialForce.com, inc. All rights reserved.
  */
@@ -6,7 +9,7 @@ import formatDuration, {
   showTab,
   recalculateDurations,
 } from "../Util";
-import { LogLine, TimeStampedNode } from "../parsers/LineParser";
+import { TimeStampedNode } from "../parsers/LineParser";
 
 jest.mock("../Browser", () => ({
   decodeEntities: (text: string) => {

--- a/log-viewer/modules/parsers/LineParser.ts
+++ b/log-viewer/modules/parsers/LineParser.ts
@@ -2015,7 +2015,9 @@ export function parseLine(
 
 export default async function parseLog(log: string) {
   const start = log.match(/^.*EXECUTION_STARTED.*$/m)?.index || -1;
-  const rawLines = log.substring(start).split("\n");
+  // Matches CRLF (\r\n) + LF (\n)
+  // the ? matches the previous token 0 or 1 times.
+  const rawLines = log.substring(start).split(/\r?\n/);
 
   // reset global variables to be captured during parsing
   logLines = [];


### PR DESCRIPTION
# Description

Previously the log parser would only handle LF (\n) line endings.
Now it will handle both CRLF (\r\n) + LF (\n) via the regex `/\r?\n/`

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Changes
- Line parser handles both CRLF (\r\n) + LF (\n) via the regex `/\r?\n/`

fixes #108
