### PR TITLE
feat: round log size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Timeline flickering/resizing when tooltip moved to bottom right ([#87][#87])
 - Timeline not displaying `VF_APEX_CALL_START` log events ([#97][#97])
 - Incorrect Totaltime on status bar and analysis tab ([#95][#95])
-  - Now uses the timestamp of the last `EXECUTION_FINISED` event to determine total time
-  - If there are no `EXECUTION_FINISED` events the last event with a timestamp is used
+  - Now uses the timestamp of the last `EXECUTION_FINISHED` event to determine total time
+  - If there are no `EXECUTION_FINISHED` events the last event with a timestamp is used
 - Log parsing not handling both CRLF and LF line endings ([#108][#108])
 
 ## [1.4.1] - 2022-01-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Round the log size on the `Log: Load Apex Log For Analysis` command results to 2DP ([#91][#91])
+- Rounded the log size on the `Log: Load Apex Log For Analysis` command results to 2DP ([#91][#91])
 
 ## [1.4.2] - 2022-03-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Round the log size on the `Log: Load Apex Log For Analysis` command results to 2DP ([#91][#91])
+
 ## [1.4.2] - 2022-03-14
 
 ### Fixed
@@ -118,3 +124,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#97]: https://github.com/financialforcedev/debug-log-analyzer/issues/97
 [#99]: https://github.com/financialforcedev/debug-log-analyzer/issues/99
 [#108]: https://github.com/financialforcedev/debug-log-analyzer/issues/108
+[#91]: https://github.com/financialforcedev/debug-log-analyzer/issues/91

--- a/lana/src/commands/LoadLogFile.ts
+++ b/lana/src/commands/LoadLogFile.ts
@@ -75,9 +75,9 @@ export class LoadLogFile {
         return new Item(
           `${new Date(r.StartTime).toLocaleString()} ${r.Operation}`,
           "",
-          `${r.Id} ${r.Status} ${r.DurationMilliseconds}ms ${
+          `${r.Id} ${r.Status} ${r.DurationMilliseconds} ms ${(
             r.LogLength / 1024
-          }kB`
+          ).toFixed(2)} KB`
         );
       });
 

--- a/lana/src/commands/LoadLogFile.ts
+++ b/lana/src/commands/LoadLogFile.ts
@@ -69,12 +69,7 @@ export class LoadLogFile {
       .sort((a, b) => {
         const aDate = Date.parse(a.StartTime);
         const bDate = Date.parse(b.StartTime);
-        if (aDate === bDate) {
-          return 0;
-        } else if (aDate < bDate) {
-          return 1;
-        }
-        return -1;
+        return bDate - aDate;
       })
       .map((r) => {
         return new Item(

--- a/lana/src/commands/LoadLogFile.ts
+++ b/lana/src/commands/LoadLogFile.ts
@@ -88,14 +88,14 @@ export class LoadLogFile {
         return bDate - aDate;
       })
       .map((r) => {
-        return new DebugLogItem(
-          `${new Date(r.StartTime).toLocaleString()} ${r.Operation}`,
-          "",
-          `${r.Id} ${r.Status} ${r.DurationMilliseconds} ms ${(
-            r.LogLength / 1024
-          ).toFixed(2)} KB`,
-          r.Id
-        );
+        const name = `${r.LogUser.Name} - ${r.Operation}`;
+        const description = `${(r.LogLength / 1024).toFixed(2)} KB ${
+          r.DurationMilliseconds
+        } ms`;
+        const detail = `${new Date(r.StartTime).toLocaleString()} - ${
+          r.Status
+        } - ${r.Id}`;
+        return new DebugLogItem(name, description, detail, r.Id);
       });
 
     const picked = await QuickPick.pick(items, new Options("Select a logfile"));

--- a/lana/src/sfdx/Command.ts
+++ b/lana/src/sfdx/Command.ts
@@ -18,8 +18,8 @@ export class Command {
         command,
         (
           error: ExecException | null,
-          stdOut: Buffer | String,
-          stdErr: Buffer | String
+          stdOut: Buffer | string,
+          stdErr: Buffer | string
         ) => {
           if (error === null) {
             const out = stdOut as Buffer;

--- a/lana/src/sfdx/logs/GetLogFiles.ts
+++ b/lana/src/sfdx/logs/GetLogFiles.ts
@@ -10,6 +10,13 @@ export interface GetLogFilesResult {
   DurationMilliseconds: number;
   Location: string;
   LogLength: number;
+  LogUser: {
+    attributes: {
+      type: string;
+      url: string;
+    };
+    Name: string;
+  };
   Operation: string;
   Request: string;
   StartTime: string;

--- a/lana/src/sfdx/logs/GetLogFiles.ts
+++ b/lana/src/sfdx/logs/GetLogFiles.ts
@@ -5,7 +5,7 @@ import { SFDX, SFDXResponse } from "../SFDX";
 
 export interface GetLogFilesResult {
   /* eslint-disable @typescript-eslint/naming-convention */
-  Id: String;
+  Id: string;
   Application: string;
   DurationMilliseconds: number;
   Location: string;

--- a/log-viewer/modules/Database.ts
+++ b/log-viewer/modules/Database.ts
@@ -75,7 +75,7 @@ export class DatabaseAccess {
     }
   }
 
-  private upsert(map: Map<String, DatabaseEntry>, line: LogLine, stack: Stack) {
+  private upsert(map: Map<string, DatabaseEntry>, line: LogLine, stack: Stack) {
     let stackIndex = this.internStack(stack);
     let entry = map.get(line.text);
     if (!entry) {
@@ -90,7 +90,7 @@ export class DatabaseAccess {
 
   private internStack(stack: Stack): number {
     this.stacks.push([...stack].reverse());
-    return this.stacks.length-1;
+    return this.stacks.length - 1;
   }
 }
 


### PR DESCRIPTION
# Description

- Rounds the log size on the `Log: Load APEX Log for Analysis` output list to 2DP
- Rearranges content to be more similar to the SF SFDX version of the command to make this more familiar when switching between them.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

### Any images/ gifs (if appropriate)

**New**
![image](https://user-images.githubusercontent.com/4013877/158606490-bb2db986-bb09-4daf-b9a8-f24fe8d3e846.png)

**Old**
![image](https://user-images.githubusercontent.com/4013877/158606845-7d10fb41-9dab-4610-bd83-a8fa7e549efb.png)

resolves #91 
