### PR TITLE
fix: length of children

### DIFF
--- a/log-viewer/modules/Main.ts
+++ b/log-viewer/modules/Main.ts
@@ -123,8 +123,7 @@ async function insertPackageWrappers(node: LogLine) {
   let lastPkg,
     i = 0;
   if (children) {
-    const len = children.length;
-    while (i < len) {
+    while (i < children.length) {
       const child = children[i],
         childType = child.type;
 


### PR DESCRIPTION
child array length can change so length can not be assigned to a var.

# Description

Bug introduced in #119 

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

fixes #90 
