### PR TITLE
feat: Improved performance getting log file from an org when using the `Log: Load Apex Log For Analysis` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rounded the log size on the `Log: Load Apex Log For Analysis` command results to 2DP ([#91][#91])
 - Improved log parsing to tolerate false exits ([#88][#88])
   - Checks for false exits before un-winding the call stack, by checking down the stack to see if the EXIT matches something already on the stack.
-- Reduced CPU usage when Timeline is open but no changes are occuring ([#90][#90])
+- Greatly reduced CPU usage when Timeline is open but no changes are occuring ([#90][#90])
+- Improved performance getting log file from an org when using the `Log: Load Apex Log For Analysis` command ([#123][#123])
 
 ## [1.4.2] - 2022-03-14
 
@@ -135,3 +136,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#88]: https://github.com/financialforcedev/debug-log-analyzer/issues/88
 [#90]: https://github.com/financialforcedev/debug-log-analyzer/issues/90
 [#112]: https://github.com/financialforcedev/debug-log-analyzer/issues/112
+[#123]: https://github.com/financialforcedev/debug-log-analyzer/issues/123

--- a/lana/.gitignore
+++ b/lana/.gitignore
@@ -6,23 +6,13 @@
 *.ipr
 *.iws
 .idea/
+.DS_Store
+
+node_modules/*
 out/
+**/dist/*
 
-.tests/
-target/
-node_modules/
-**/dist/bundle.js
-**/dist/spa/
-**/dist/sfdx/
-**/dist/server.jar
-
-vsix/dist/config.json
-lana/dist/config.json
 *.vsix
-
-sfdx/dist/lib/
-sfdx/dist/oclif.manifest.json
-*.tgz
 
 README.md
 CHANGELOG.md

--- a/lana/src/SymbolFinder.ts
+++ b/lana/src/SymbolFinder.ts
@@ -16,12 +16,12 @@ export class SymbolFinder {
   findSymbol(wsPath: string, symbol: string): string | null {
     const ws = Workspaces.get(wsPath);
     // The .d.ts entry is currently wrong, findType returns a string array
-    const paths = (ws.findType(symbol) as unknown) as string[];
-    if (paths.length == 0) {
-      const parts = symbol.split('.');
+    const paths = ws.findType(symbol) as unknown as string[];
+    if (paths.length === 0) {
+      const parts = symbol.split(".");
       if (parts.length > 1) {
-        parts.pop()
-        return this.findSymbol(wsPath, parts.join('.'))
+        parts.pop();
+        return this.findSymbol(wsPath, parts.join("."));
       } else {
         return null;
       }

--- a/lana/src/commands/ShowLogFile.ts
+++ b/lana/src/commands/ShowLogFile.ts
@@ -6,7 +6,6 @@ import { Uri, window } from "vscode";
 import { Context } from "../Context";
 import { QuickPickWorkspace } from "../display/QuickPickWorkspace";
 import * as path from "path";
-import { promises as fs } from "fs";
 import { LogView } from "./LogView";
 import { Command } from "./Command";
 import { appName } from "../Main";

--- a/lana/src/sfdx/logs/GetLogFile.ts
+++ b/lana/src/sfdx/logs/GetLogFile.ts
@@ -5,7 +5,15 @@
 import { SFDX } from "../SFDX";
 
 export class GetLogFile {
-  static async apply(path: string, logId: string): Promise<string> {
-    return SFDX.apply(path, ["force:apex:log:get", "--logid", logId]);
+  static async apply(
+    path: string,
+    logDir: string,
+    logId: string
+  ): Promise<string> {
+    return SFDX.apply(path, [
+      "force:apex:log:get",
+      `--outputdir ${logDir}`,
+      `--logid ${logId}`,
+    ]);
   }
 }


### PR DESCRIPTION
# Description

- Improved performance getting log file from an org when using the `Log: Load Apex Log For Analysis` command

- Switch using `writeFile` for `--outputdir` in the `force:apex:log:get` sfdx command. 
The force:apex:log:get implementation uses a writestream which is faster.

a 20mb log will download and display in ~12s instead of ~20s (on my machine)

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

resolves #123 
