### PR TITLE
feat: More easily differentiate between "Flows" and "Process Builders" in the timeline and call tree 

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-  "tabWidth": 2
+  "tabWidth": 2,
+  "printWidth": 100
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved log parsing to tolerate false exits ([#88][#88])
   - Checks for false exits before un-winding the call stack, by checking down the stack to see if the EXIT matches something already on the stack.
 - Reduced CPU usage when Timeline is open but no changes are occuring ([#90][#90])
+- More easily differentiate between "Flows" and "Process Builders" in the timeline and call tree ([#114][#114])
 
 ## [1.4.2] - 2022-03-14
 
@@ -135,3 +136,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#88]: https://github.com/financialforcedev/debug-log-analyzer/issues/88
 [#90]: https://github.com/financialforcedev/debug-log-analyzer/issues/90
 [#112]: https://github.com/financialforcedev/debug-log-analyzer/issues/112
+[#114]: https://github.com/financialforcedev/debug-log-analyzer/issues/114

--- a/lana/.gitignore
+++ b/lana/.gitignore
@@ -6,23 +6,11 @@
 *.ipr
 *.iws
 .idea/
-out/
 
-.tests/
-target/
-node_modules/
-**/dist/bundle.js
-**/dist/spa/
-**/dist/sfdx/
-**/dist/server.jar
-
-vsix/dist/config.json
-lana/dist/config.json
 *.vsix
 
-sfdx/dist/lib/
-sfdx/dist/oclif.manifest.json
-*.tgz
+out/
+node_modules/*
 
 README.md
 CHANGELOG.md

--- a/log-viewer/.gitignore
+++ b/log-viewer/.gitignore
@@ -1,4 +1,6 @@
-node_modules/
-out/bundle.js
-out/bundle.js.map
-out/sample.log
+.DS_Store
+
+node_modules/*
+out/*
+!out/index.html
+

--- a/log-viewer/modules/Timeline.ts
+++ b/log-viewer/modules/Timeline.ts
@@ -158,13 +158,11 @@ function drawScale(ctx: CanvasRenderingContext2D) {
   // TODO: This is a bit brute force, but it works. maybe rework it?
   // from 1 micro second to 1 second
   const microSecsToShow = [
-    1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000, 50000,
-    100000, 200000, 500000, 1000000,
+    1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000, 50000, 100000, 200000,
+    500000, 1000000,
   ];
   const closestIncrement = microSecsToShow.reduce(function (prev, curr) {
-    return Math.abs(curr - microSecPixelGap) < Math.abs(prev - microSecPixelGap)
-      ? curr
-      : prev;
+    return Math.abs(curr - microSecPixelGap) < Math.abs(prev - microSecPixelGap) ? curr : prev;
   });
 
   ctx.strokeStyle = "#E0E0E0";
@@ -293,11 +291,7 @@ function resetView() {
 
 function resize() {
   const { clientWidth: newWidth, clientHeight: newHeight } = container;
-  if (
-    newWidth &&
-    newHeight &&
-    (newWidth !== displayWidth || newHeight !== displayHeight)
-  ) {
+  if (newWidth && newHeight && (newWidth !== displayWidth || newHeight !== displayHeight)) {
     canvas.width = displayWidth = newWidth;
     canvas.height = displayHeight = newHeight;
     ctx.setTransform(1, 0, 0, 1, 0, displayHeight); // shift y-axis down so that 0,0 is bottom-lefts
@@ -411,12 +405,7 @@ function findByPosition(
     if (targetDepth >= childDepth) {
       const len = node.children.length;
       for (let c = 0; c < len; ++c) {
-        const target = findByPosition(
-          node.children[c],
-          childDepth,
-          x,
-          targetDepth
-        );
+        const target = findByPosition(node.children[c], childDepth, x, targetDepth);
         if (target) {
           return target;
         }
@@ -429,12 +418,8 @@ function findByPosition(
 
 function showTooltip(offsetX: number, offsetY: number) {
   if (!dragging && container && tooltip) {
-    const depth = ~~(
-      ((displayHeight - offsetY - state.offsetY) / realHeight) *
-      maxY
-    );
-    let tooltipText =
-      findTimelineTooltip(offsetX, depth) || findTruncatedTooltip(offsetX);
+    const depth = ~~(((displayHeight - offsetY - state.offsetY) / realHeight) * maxY);
+    let tooltipText = findTimelineTooltip(offsetX, depth) || findTruncatedTooltip(offsetX);
 
     if (tooltipText) {
       showTooltipWithText(offsetX, offsetY, tooltipText, tooltip, container);
@@ -447,30 +432,28 @@ function findTimelineTooltip(x: number, depth: number): HTMLDivElement | null {
   if (target) {
     const toolTip = document.createElement("div");
     const brElem = document.createElement("br");
+    let displayText = target.text;
+    if (target.suffix) {
+      displayText += target.suffix;
+    }
 
     toolTip.appendChild(document.createTextNode(target.type));
     toolTip.appendChild(brElem.cloneNode());
-    toolTip.appendChild(document.createTextNode(target.text));
+    toolTip.appendChild(document.createTextNode(displayText));
     if (target.timestamp && target.duration && target.selfTime) {
       toolTip.appendChild(brElem.cloneNode());
-      toolTip.appendChild(
-        document.createTextNode("timestamp: " + target.timestamp)
-      );
+      toolTip.appendChild(document.createTextNode("timestamp: " + target.timestamp));
       if (target.exitStamp) {
         toolTip.appendChild(document.createTextNode(" => " + target.exitStamp));
         toolTip.appendChild(brElem.cloneNode());
         toolTip.appendChild(
-          document.createTextNode(
-            `duration: ${formatDuration(target.duration)}`
-          )
+          document.createTextNode(`duration: ${formatDuration(target.duration)}`)
         );
         if (target.cpuType === "free") {
           toolTip.appendChild(document.createTextNode(" (free)"));
         } else {
           toolTip.appendChild(
-            document.createTextNode(
-              ` (self ${formatDuration(target.selfTime)})`
-            )
+            document.createTextNode(` (self ${formatDuration(target.selfTime)})`)
           );
         }
       }
@@ -491,10 +474,7 @@ function findTruncatedTooltip(x: number): HTMLDivElement | null {
       startTime = thisEntry[1],
       endTime = nextEntry[1] ?? totalDuration;
 
-    if (
-      x >= startTime * state.zoom - state.offsetX &&
-      x <= endTime * state.zoom - state.offsetX
-    ) {
+    if (x >= startTime * state.zoom - state.offsetX && x <= endTime * state.zoom - state.offsetX) {
       const toolTip = document.createElement("div");
       toolTip.textContent = thisEntry[0];
       return toolTip;
@@ -563,10 +543,7 @@ function onMouseMove(evt: any) {
 
 function onClickCanvas(evt: any) {
   if (!dragging && tooltip.style.display === "block") {
-    const depth = ~~(
-      ((displayHeight - lastMouseY - state.offsetY) / realHeight) *
-      maxY
-    );
+    const depth = ~~(((displayHeight - lastMouseY - state.offsetY) / realHeight) * maxY);
     const target = findByPosition(timelineRoot, 0, lastMouseX, depth);
     if (target && target.timestamp) {
       showTreeNode(target.timestamp);
@@ -598,10 +575,7 @@ function handleMouseMove(evt: MouseEvent) {
     state.offsetX = Math.max(0, Math.min(maxWidth, state.offsetX - movementX));
 
     const maxVertOffset = ~~(realHeight - displayHeight + displayHeight / 4);
-    state.offsetY = Math.min(
-      0,
-      Math.max(-maxVertOffset, state.offsetY - movementY)
-    );
+    state.offsetY = Math.min(0, Math.max(-maxVertOffset, state.offsetY - movementY));
   }
 }
 
@@ -614,10 +588,7 @@ function handleScroll(evt: WheelEvent) {
     const oldZoom = state.zoom;
     let zoomDelta = (deltaY / 1000) * state.zoom;
     const updatedZoom = state.zoom - zoomDelta;
-    zoomDelta =
-      updatedZoom >= state.defaultZoom
-        ? zoomDelta
-        : state.zoom - state.defaultZoom;
+    zoomDelta = updatedZoom >= state.defaultZoom ? zoomDelta : state.zoom - state.defaultZoom;
     //TODO: work out a proper max zoom
     // stop zooming at 0.0001 ms
     zoomDelta = updatedZoom <= 0.3 ? zoomDelta : state.zoom - 0.3;

--- a/log-viewer/modules/parsers/TreeParser.ts
+++ b/log-viewer/modules/parsers/TreeParser.ts
@@ -35,22 +35,15 @@ function isMatchingEnd(method: LogLine, endLine: LogLine) {
   return (
     method.exitTypes &&
     method.exitTypes.includes(endLine.type) &&
-    (!endLine.lineNumber ||
-      !method.lineNumber ||
-      endLine.lineNumber === method.lineNumber)
+    (!endLine.lineNumber || !method.lineNumber || endLine.lineNumber === method.lineNumber)
   );
 }
 
-function endMethod(
-  method: LogLine,
-  endLine: LogLine,
-  lineIter: LineIterator,
-  stack: LogLine[]
-) {
+function endMethod(method: LogLine, endLine: LogLine, lineIter: LineIterator, stack: LogLine[]) {
   method.exitStamp = endLine.timestamp;
   if (method.onEnd) {
     // the method wants to see the exit line
-    method.onEnd(endLine);
+    method.onEnd(endLine, stack);
   }
 
   // is this a 'good' end line?
@@ -65,7 +58,7 @@ function endMethod(
       return true; // we match a method further down the stack - unwind
     }
     // we found an exit event on its own e.g a `METHOD_EXIT` with an entry
-      truncateLog(endLine.timestamp, "Unexpected-Exit", "unexpected");
+    truncateLog(endLine.timestamp, "Unexpected-Exit", "unexpected");
     return false; // we have no matching method - ignore
   }
 }
@@ -117,7 +110,7 @@ function getMethod(lineIter: LineIterator, method: LogLine, stack: LogLine[]) {
 
     stack.pop();
     method.children = children;
-    }
+  }
 
   recalculateDurations(method);
 


### PR DESCRIPTION
# Description

- Makes it easier to differentiate between "Flows" and "Process Builders" in the timeline and call tree 

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Changes
- (Process Builder) or (Flow) shown after the `FLOW_START_INTERVIEWS` event line e.g `FLOW_START_INTERVIEWS : Account Process Builder (Process Builder) - 478.274ms (self 1.925ms)`
- (Process Builder) or (Flow) shown on the timeline tooltip for `FLOW_START_INTERVIEWS` event. 

### Any images/ gifs (if appropriate)
![tooltip-flow](https://user-images.githubusercontent.com/4013877/166680328-7d3f367a-e180-4e58-bc2f-71a522bb7b09.png)

![tooltip-pb](https://user-images.githubusercontent.com/4013877/166680377-aff643cb-b095-43af-9fb8-7ca67639075c.png)

resolves #114 
