### PR TITLE
bug: timeline background opaque

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Some detail lines not being shown on calltree ([#130][#130])
 - Tooltip not hiding when moving to a part of timeline where the tooltip should not be shown ([#131][#131])
+- Timeline background shown as black in some browsers ([#137][#137])
 
 ## [1.4.2] - 2022-03-14
 
@@ -146,3 +147,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#114]: https://github.com/financialforcedev/debug-log-analyzer/issues/114
 [#130]: https://github.com/financialforcedev/debug-log-analyzer/issues/130
 [#131]: https://github.com/financialforcedev/debug-log-analyzer/issues/131
+[#137]: https://github.com/financialforcedev/debug-log-analyzer/issues/137

--- a/log-viewer/modules/Timeline.ts
+++ b/log-viewer/modules/Timeline.ts
@@ -315,7 +315,7 @@ export default async function renderTimeline(rootMethod: RootNode) {
   renderTimelineKey();
   container = document.getElementById("timelineWrapper") as HTMLDivElement;
   canvas = document.getElementById("timeline") as HTMLCanvasElement;
-  ctx = canvas.getContext("2d", { alpha: false })!; // can never be null since context (2d) is a supported type.
+  ctx = canvas.getContext("2d")!; // can never be null since context (2d) is a supported type.
   timelineRoot = rootMethod;
   calculateSizes();
   nodesToRectangles([timelineRoot], -1);
@@ -420,9 +420,9 @@ function showTooltip(offsetX: number, offsetY: number) {
   if (!dragging && container && tooltip) {
     const depth = ~~(((displayHeight - offsetY - state.offsetY) / realHeight) * maxY);
     let tooltipText = findTimelineTooltip(offsetX, depth) || findTruncatedTooltip(offsetX);
-      showTooltipWithText(offsetX, offsetY, tooltipText, tooltip, container);
-    }
+    showTooltipWithText(offsetX, offsetY, tooltipText, tooltip, container);
   }
+}
 
 function findTimelineTooltip(x: number, depth: number): HTMLDivElement | null {
   const target = findByPosition(timelineRoot, 0, x, depth);


### PR DESCRIPTION
# Description

- Remove the `, { alpha: false }` option so the timeline is transparent and the background can be seen (and inherited from themes) in browsers that support the alpha setting, instead of the background appearing to be black in all cases.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change


### Any images/ gifs (if appropriate)

**Before**

![image](https://user-images.githubusercontent.com/4013877/178235786-d1b5b9c5-3904-4765-94b5-cc5bb4f92902.png)

**After**

![image](https://user-images.githubusercontent.com/4013877/178239975-85f4eb77-c1d3-4b0a-bc18-a901d1beb56e.png)


fixes #137 
