### PR TITLE
build(publish): publish to Open VSX Registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,4 +28,4 @@ jobs:
         run: |
           cd lana
           vsce publish -p ${{ secrets.VSCE_TOKEN }} --packagePath lana-${{ github.event.release.tag_name }}.vsix
-          npx ovsx publish lana-${{ github.event.release.tag_name }}.vsix -p ${{ secrets.OVSX_TOKEN }}
+          ovsx publish lana-${{ github.event.release.tag_name }}.vsix -p ${{ secrets.OVSX_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: "16"
       - name: Install vsce
-        run: npm install --global vsce
+        run: npm install --global vsce ovsx
       - name: Dependencies
         run: |
           cd lana
@@ -24,7 +24,8 @@ jobs:
         run: |
           cd lana
           vsce package
-      - name: Publish to Marketplace
+      - name: Publish to VS Code Marketplace + Open VSX Registry
         run: |
           cd lana
           vsce publish -p ${{ secrets.VSCE_TOKEN }} --packagePath lana-${{ github.event.release.tag_name }}.vsix
+          npx ovsx publish lana-${{ github.event.release.tag_name }}.vsix -p ${{ secrets.OVSX_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved performance getting log file from an org when using the `Log: Load Apex Log For Analysis` command ([#123][#123])
 - More easily differentiate between "Flows" and "Process Builders" in the timeline and call tree ([#114][#114])
 - Counts on Calltree for Throw (T), DML (D) & SOQL (S) markers, which shows how many of each statement type are descendants of a node ([#135][#135])
-- Apex Log Analyzer to be published to the Open VSX Registry as well as the VSCode Marketplace([#23][#23])
+- Apex Log Analyzer to be published to the Open VSX Registry as well as the VSCode Marketplace ([#23][#23])
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved performance getting log file from an org when using the `Log: Load Apex Log For Analysis` command ([#123][#123])
 - More easily differentiate between "Flows" and "Process Builders" in the timeline and call tree ([#114][#114])
 - Counts on Calltree for Throw (T), DML (D) & SOQL (S) markers, which shows how many of each statement type are descendants of a node ([#135][#135])
+- Apex Log Analyzer to be published to the Open VSX Registry as well as the VSCode Marketplace([#23][#23])
 
 ### Fixed
 
@@ -156,3 +157,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#137]: https://github.com/financialforcedev/debug-log-analyzer/issues/137
 [#135]: https://github.com/financialforcedev/debug-log-analyzer/issues/135
 [#139]: https://github.com/financialforcedev/debug-log-analyzer/issues/139
+[#23]: https://github.com/financialforcedev/debug-log-analyzer/issues/23

--- a/lana/package.json
+++ b/lana/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lana",
   "displayName": "Apex Log Analyzer",
-  "version": "1.5.0-beta.1",
+  "version": "1.4.2",
   "description": "Analyzer for Salesforce debug logs - Visualize code execution via a Flame graph and identify performance and SOQL/DML problems via Method and Database analysis",
   "keywords": [
     "apex",

--- a/lana/package.json
+++ b/lana/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lana",
   "displayName": "Apex Log Analyzer",
-  "version": "1.4.2",
+  "version": "1.5.0-beta.1",
   "description": "Analyzer for Salesforce debug logs - Visualize code execution via a Flame graph and identify performance and SOQL/DML problems via Method and Database analysis",
   "keywords": [
     "apex",


### PR DESCRIPTION
build(publish): add step to publish to Open VSX Registry

# Description

- Updates the publish workflow to also publish to the Open VSX Registry
This is the marketplace used by Salesforce Code Builder and will allow the analyzer to be used from Code Builder.

It is an open source alternative to vscode marketplace.
https://open-vsx.org/

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Changes

- Update publish.yml to publish to Open vsx registry

resolves #23 
