### PR TITLE
feat: Added message functionality to pass stream log data

### DIFF
--- a/log-viewer/modules/Main.ts
+++ b/log-viewer/modules/Main.ts
@@ -257,6 +257,8 @@ function handleMessage(evt: MessageEvent) {
       setColors(message.data.timeline.colors);
       renderTimelineKey();
       break;
+    case 'streamLog':
+      displayLog(message.data, message.name, '');
   }
 }
 


### PR DESCRIPTION
# Description

This pull requests adds a new message capability in order to send log without having a file.
This is used in the context of a browser extension I am developing to display trace directly in the developer tools (https://github.com/swisscat/sf-xp-debugger). The log-viewer is used within an iframe and is passed the log contents.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Changes

- Added new message 'streamLog'

### Any images/ gifs (if appropriate)

![SampleTrace](https://user-images.githubusercontent.com/10150603/189987798-99589de6-fb09-4665-ade7-85b75dd19b64.png)

resolves #168
