### PR TITLE
fix: custom colors for timeline from vscode prefs - v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2022-10-04
+
+### Fixed
+
+- Fixes custom timeline event colors not being used from vscode preferences ([#163][#163])
+
 ## [1.5.0] - 2022-08-08
 
 ## Added
@@ -159,3 +165,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#135]: https://github.com/financialforcedev/debug-log-analyzer/issues/135
 [#139]: https://github.com/financialforcedev/debug-log-analyzer/issues/139
 [#23]: https://github.com/financialforcedev/debug-log-analyzer/issues/23
+[#163]: https://github.com/financialforcedev/debug-log-analyzer/issues/163

--- a/lana/package-lock.json
+++ b/lana/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lana",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "lana",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "pkgforce": "^2.1.4"

--- a/lana/package.json
+++ b/lana/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lana",
   "displayName": "Apex Log Analyzer",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Analyzer for Salesforce debug logs - Visualize code execution via a Flame graph and identify performance and SOQL/DML problems via Method and Database analysis",
   "keywords": [
     "apex",

--- a/log-viewer/modules/Timeline.ts
+++ b/log-viewer/modules/Timeline.ts
@@ -18,6 +18,18 @@ interface Rect {
   w: number;
 }
 
+/* eslint-disable @typescript-eslint/naming-convention */
+interface TimelineColors {
+  'Code Unit': '#6BAD68';
+  DML: '#22686D';
+  Flow: '#237A72';
+  Method: '#328C72';
+  SOQL: '#4B9D6E';
+  'System Method': '#2D4455';
+  Workflow: '#285663';
+}
+/* eslint-enable @typescript-eslint/naming-convention */
+
 const scaleY = -15,
   strokeColor = "#B0B0B0",
   textColor = "#FFFFFF",
@@ -340,11 +352,9 @@ export default async function renderTimeline(rootMethod: RootNode) {
   }
 }
 
-// todo: chnage to map? or use interface for timelineColors?
-export function setColors(timelineColors: any) {
-  for (const keyName in keyMap) {
-    const keyMeta = keyMap.get(keyName as TimelineKey)!;
-    const newColor = timelineColors[keyMeta.label];
+export function setColors(timelineColors: TimelineColors) {
+  for (const keyMeta of keyMap.values()) {
+    const newColor = timelineColors[keyMeta.label as keyof TimelineColors];
     if (newColor) {
       keyMeta.fillColor = newColor;
     }


### PR DESCRIPTION
Fixes the setting of custom colors on the timeline from vscode settings.

# Description

- Fixes the custom color preferences from vscode not being used

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Changes

- Fix color prefs fro vscode settings not being used
- Update release
- Update change log

### Any images/ gifs (if appropriate)
![image](https://user-images.githubusercontent.com/4013877/193846346-c33ff73a-b23a-41fd-a910-02d502c2e04f.png)

fixes #163 
