### PR TITLE
fix: breadcrumb text being unreadable on dark themes

### DIFF
--- a/log-viewer/modules/TreeView.ts
+++ b/log-viewer/modules/TreeView.ts
@@ -549,13 +549,14 @@ function showBreadcrumb(nameNode: HTMLElement | null) {
     markedNode.classList.remove('marked');
   }
 
-  if (nameNode === null) {
+  const closestNameNode = <HTMLElement>nameNode?.closest('.name');
+  if (!closestNameNode || !closestNameNode.matches('.name')) {
     return;
   }
-  nameNode.classList.add('marked');
-  markedNode = nameNode;
+  closestNameNode.classList.add('marked');
+  markedNode = closestNameNode;
 
-  let node = nameNode.line ? nameNode : getParentNode(nameNode);
+  let node = closestNameNode.line ? nameNode : getParentNode(nameNode);
   while (node && node.line !== treeRoot) {
     insertCrumb(breadcrumbContainer, node);
     node = getParentNode(node);

--- a/log-viewer/resources/css/TreeView.css
+++ b/log-viewer/resources/css/TreeView.css
@@ -36,8 +36,8 @@
 .crumb {
   display: inline-block;
   padding: 0 5px;
-  background-color: beige;
-  border: solid 1px blue;
+  border: solid 1px var(--vscode-inputOption-activeBorder, blue);
+  background-color: var(--vscode-inputOption-activeBackground);
   border-radius: 10px;
   margin: 4px 2px 10px 2px;
   white-space: nowrap;
@@ -67,7 +67,8 @@
   display: none;
 }
 .marked {
-  border: dashed blue 2px;
+  border: dashed 1px var(--vscode-inputOption-activeBorder, blue);
+  background-color: var(--vscode-inputOption-activeBackground);
 }
 .toggle {
   cursor: pointer;


### PR DESCRIPTION
fix: breadcrumb text being unreadable on dark themes

The background was always light but the text color changes to light on dark themes and was therefore unreadable

# Description

- Makes the breadcrumbs readable for dark themes

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

### Any images/ gifs (if appropriate)
![image](https://user-images.githubusercontent.com/4013877/197003019-2c8121d2-c16c-4334-b7b1-1ed3aaed84c7.png)

fixes #142 
