### PR TITLE
bug: some timeline events with duration not shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Goto code from click to CMD/CTRL and click. Breadcrumbs are shown on click instead. ([#142][#142])
 
+### Fixed
+
+- Timeline not showing events if the event occurs outside the `EXECUTION_STARTED` + `EXECUTION_FINISHED` events ([#180][#180])
+
 ## [1.5.1] - 2022-10-04
 
 ### Fixed
@@ -177,3 +181,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#23]: https://github.com/financialforcedev/debug-log-analyzer/issues/23
 [#142]: https://github.com/financialforcedev/debug-log-analyzer/issues/142
 [#163]: https://github.com/financialforcedev/debug-log-analyzer/issues/163
+[#180]: https://github.com/financialforcedev/debug-log-analyzer/issues/180

--- a/log-viewer/modules/Main.ts
+++ b/log-viewer/modules/Main.ts
@@ -81,27 +81,27 @@ async function markContainers(node: TimedNode) {
   const children = node.children,
     len = children.length;
 
-  node.containsDml = 0;
-  node.containsSoql = 0;
-  node.containsThrown = 0;
+  node.totalDmlCount = 0;
+  node.totalSoqlCount = 0;
+  node.totalThrownCount = 0;
 
   for (let i = 0; i < len; ++i) {
     const child = children[i];
 
     if (child instanceof TimedNode) {
       if (child.type === 'DML_BEGIN') {
-        ++node.containsDml;
+        ++node.totalDmlCount;
       }
       if (child.type === 'SOQL_EXECUTE_BEGIN') {
-        ++node.containsSoql;
+        ++node.totalSoqlCount;
       }
       if (child.type === 'EXCEPTION_THROWN') {
-        ++node.containsThrown;
+        ++node.totalThrownCount;
       }
       markContainers(child);
-      node.containsDml += child.containsDml;
-      node.containsSoql += child.containsSoql;
-      node.containsThrown += child.containsThrown;
+      node.totalDmlCount += child.totalDmlCount;
+      node.totalSoqlCount += child.totalSoqlCount;
+      node.totalThrownCount += child.totalThrownCount;
     }
   }
 }
@@ -134,9 +134,11 @@ async function insertPackageWrappers(node: Method) {
           lastPkg.children.push(child); // move child into the pkg
         }
 
-        lastPkg.containsDml = child.containsDml + (childType === 'DML_BEGIN' ? 1 : 0);
-        lastPkg.containsSoql = child.containsSoql + (childType === 'SOQL_EXECUTE_BEGIN' ? 1 : 0);
-        lastPkg.containsThrown = child.containsThrown + (childType === 'EXCEPTION_THROWN' ? 1 : 0);
+        lastPkg.totalDmlCount = child.totalDmlCount + (childType === 'DML_BEGIN' ? 1 : 0);
+        lastPkg.totalSoqlCount =
+          child.totalSoqlCount + (childType === 'SOQL_EXECUTE_BEGIN' ? 1 : 0);
+        lastPkg.totalThrownCount =
+          child.totalThrownCount + (childType === 'EXCEPTION_THROWN' ? 1 : 0);
         lastPkg.exitStamp = child.exitStamp; // move the end
         lastPkg.recalculateDurations();
         if (child instanceof Method) {

--- a/log-viewer/modules/TreeView.ts
+++ b/log-viewer/modules/TreeView.ts
@@ -160,14 +160,14 @@ function describeMethod(node: Method): Node[] {
     methodSuffix = node.suffix || '';
 
   const prefix = [];
-  if (node.containsDml) {
-    prefix.push('D' + node.containsDml);
+  if (node.totalDmlCount) {
+    prefix.push('D' + node.totalDmlCount);
   }
-  if (node.containsSoql) {
-    prefix.push('S' + node.containsSoql);
+  if (node.totalSoqlCount) {
+    prefix.push('S' + node.totalSoqlCount);
   }
-  if (node.containsThrown) {
-    prefix.push('T' + node.containsThrown);
+  if (node.totalThrownCount) {
+    prefix.push('T' + node.totalThrownCount);
   }
 
   let dbPrefix = '';

--- a/log-viewer/modules/__tests__/TreeParser.test.ts
+++ b/log-viewer/modules/__tests__/TreeParser.test.ts
@@ -384,6 +384,44 @@ describe('getRootMethod tests', () => {
     const interViewEnd = interViewsBegin.children[1];
     expect(interViewEnd.type).toBe('FLOW_START_INTERVIEW_END');
   });
+
+  it('Root exitStamp should match last line pair with a duration', async () => {
+    const log =
+      '17:52:34.317 (1350000000)|EXECUTION_STARTED\n' +
+      '17:52:35.317 (1363038330)|CODE_UNIT_STARTED|[EXTERNAL]|Workflow:01Id0000000roIX\n' +
+      '17:52:35.370 (1363038331)|FLOW_START_INTERVIEWS_BEGIN|1\n' +
+      '17:52:35.370 (1363038332)|FLOW_START_INTERVIEW_BEGIN|91080693a3c13822bcdbdd838a5180aed7a0e-5f03|Example Process Builder\n' +
+      '17:52:35.370 (1363038333)|FLOW_START_INTERVIEWS_BEGIN|1\n' +
+      '17:52:35.370 (1363038334)|FLOW_START_INTERVIEW_BEGIN|91080693a3c13822bcdbdd838a5180aed7a0e-5f03|Example Flow\n' +
+      '17:52:35.370 (1363038335)|FLOW_START_INTERVIEW_END|91080693a3c13822bcdbdd838a5180aed7a0e-5f03|Example Flow\n' +
+      '17:52:35.370 (1363038336)|FLOW_START_INTERVIEWS_END|1\n' +
+      '17:52:35.370 (1363038337)|FLOW_START_INTERVIEW_END|91080693a3c13822bcdbdd838a5180aed7a0e-5f03|Example Process Builder\n' +
+      '17:52:35.370 (1363038338)|FLOW_START_INTERVIEWS_END|1\n' +
+      '17:52:35.317 (1363038339)|CODE_UNIT_FINISHED|Workflow:01Id0000000roIX\n' +
+      '17:52:36.317 (1500000000)|EXECUTION_FINISHED\n' +
+      '17:52:36.320 (1510000000)|FLOW_START_INTERVIEWS_BEGIN|2\n' +
+      '17:52:36.320 (1520000000)|FLOW_START_INTERVIEWS_END|2\n' +
+      '17:52:36.321 (1530000000)|FLOW_INTERVIEW_FINISHED_LIMIT_USAGE|SOQL queries: 0 out of 100';
+
+    parseLog(log);
+    const rootMethod = getRootMethod();
+    // This should match the last node with a duration
+    // The last log line is information only (duration is 0)
+    // The last `FLOW_START_INTERVIEW_BEGIN` + `FLOW_START_INTERVIEW_END` are the last pair that will result in a duration
+    expect(rootMethod.exitStamp).toBe(1520000000);
+  });
+
+  it('Root exitStamp should match last line timestamp if none of the line pairs have duration', async () => {
+    const log =
+      '17:52:36.321 (1500000000)|FLOW_INTERVIEW_FINISHED_LIMIT_USAGE|SOQL queries: 0 out of 100\n' +
+      '17:52:37.321 (1510000000)|FLOW_INTERVIEW_FINISHED_LIMIT_USAGE|SOQL queries: 1 out of 100\n' +
+      '17:52:38.321 (1520000000)|FLOW_INTERVIEW_FINISHED_LIMIT_USAGE|SOQL queries: 2 out of 100\n' +
+      '17:52:39.321 (1530000000)|FLOW_INTERVIEW_FINISHED_LIMIT_USAGE|SOQL queries: 3 out of 100\n';
+
+    parseLog(log);
+    const rootMethod = getRootMethod();
+    expect(rootMethod.exitStamp).toBe(1530000000);
+  });
 });
 
 describe('Log Settings tests', () => {

--- a/log-viewer/modules/parsers/TreeParser.ts
+++ b/log-viewer/modules/parsers/TreeParser.ts
@@ -275,22 +275,16 @@ export class RootNode extends Method {
 
   setEndTime() {
     // We do not just want to use the very last exitStamp because it could be CUMULATIVE_USAGE which is not really part of the code execution time but does have a later time.
-    // we only want to deal with nodes that have a duration and exitStamp as no duration will not be show on the timeline.
     let endTime;
     const len = this.children.length - 1;
     for (let i = len; i >= 0; i--) {
       const child = this.children[i];
-      if (child instanceof TimedNode) {
-        // Get the latest time of the last node (with a time) to use as a default
-        // This helps to display something on the timeline if the log is malformed
-        // e.g does not contain `EXECUTION_STARTED` + `EXECUTION_FINISED`
-        endTime ??= child.exitStamp;
-        // If there is no duration on a node then it is not going to be shown on the timeline anyway
-        if (child.duration && child.exitStamp) {
-          endTime = child.exitStamp;
-          break;
-        }
+      // If there is no duration on a node then it is not going to be shown on the timeline anyway
+      if (child instanceof TimedNode && child.duration && child.exitStamp) {
+        endTime = child.exitStamp;
+        break;
       }
+      endTime ??= child.timestamp;
     }
     this.exitStamp = endTime || 0;
   }

--- a/log-viewer/modules/parsers/TreeParser.ts
+++ b/log-viewer/modules/parsers/TreeParser.ts
@@ -274,8 +274,8 @@ export class RootNode extends Method {
   }
 
   setEndTime() {
-    // We could have multiple "EXECUTION_STARTED" entries so loop backwards until we find one.
-    // We do not just want to use the last one because it is probably CUMULATIVE_USAGE which is not really part of the code execution time but does have a later time.
+    // We do not just want to use the very last exitStamp because it could be CUMULATIVE_USAGE which is not really part of the code execution time but does have a later time.
+    // we only want to deal with nodes that have a duration and exitStamp as no duration will not be show on the timeline.
     let endTime;
     const len = this.children.length - 1;
     for (let i = len; i >= 0; i--) {
@@ -285,7 +285,8 @@ export class RootNode extends Method {
         // This helps to display something on the timeline if the log is malformed
         // e.g does not contain `EXECUTION_STARTED` + `EXECUTION_FINISED`
         endTime ??= child.exitStamp;
-        if (child.type === 'EXECUTION_STARTED') {
+        // If there is no duration on a node then it is not going to be shown on the timeline anyway
+        if (child.duration && child.exitStamp) {
           endTime = child.exitStamp;
           break;
         }

--- a/log-viewer/modules/parsers/TreeParser.ts
+++ b/log-viewer/modules/parsers/TreeParser.ts
@@ -121,9 +121,9 @@ export class TimedNode extends LogLine {
   timelineKey: TimelineKey; // the formatting key for rendering this entry in the timeline
   cpuType: string; // the catagory key to collect our cpu usage
   selfTime = 0; // the net time spent in the node (when not inside children)
-  containsDml = 0; // the number of DML_BEGIN decendants in a node
-  containsSoql = 0; // the number of SOQL_EXECUTE_BEGIN decendants in a node
-  containsThrown = 0; // the number of EXCEPTION_THROWN decendants in a node
+  totalDmlCount = 0; // the number of DML_BEGIN decendants in a node
+  totalSoqlCount = 0; // the number of SOQL_EXECUTE_BEGIN decendants in a node
+  totalThrownCount = 0; // the number of EXCEPTION_THROWN decendants in a node
 
   constructor(parts: string[] | null, timelineKey: TimelineKey, cpuType: string) {
     super(parts);


### PR DESCRIPTION
# Description

If the events occured outside the `EXECUTION_STARTED` + `EXECUTION_FINISHED`
events they would not be shown.

We now use the last event with a duration and exitStamp for the exittime / duration.
The reason we check for a duration and do not just take the last event
is that an event without a duration is not going to be shown on the timeline
and in all likely hood is simply information and does not contribute towards
execution time.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

fixes #180 
