### PR TITLE
fix: some rows not expanding on calltree

### DIFF
--- a/lana/package.json
+++ b/lana/package.json
@@ -22,7 +22,6 @@
     "salesforce"
   ],
   "main": "out/Main.js",
-  "type": "module",
   "icon": "logo.png",
   "galleryBanner": {
     "color": "#1e252b",

--- a/log-viewer/modules/Analysis.ts
+++ b/log-viewer/modules/Analysis.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2020 FinancialForce.com, inc. All rights reserved.
  */
 import formatDuration from './Util';
-import { TimedNode, RootNode, totalDuration } from './parsers/TreeParser';
+import { TimedNode, RootNode } from './parsers/TreeParser';
 
 type SortKey = 'count' | 'duration' | 'selfTime' | 'name';
 
@@ -15,6 +15,7 @@ const nestedSort: Map<SortKey, SortKey[]> = new Map([
 const div = document.createElement('div');
 const span = document.createElement('span');
 const boldElem = document.createElement('b');
+let totalDuration = 0;
 
 let metricList: Metric[];
 
@@ -58,6 +59,7 @@ function addNodeToMap(map: Map<string, Metric>, node: TimedNode, key?: string) {
 export default function analyseMethods(rootMethod: RootNode) {
   const methodMap: Map<string, Metric> = new Map();
 
+  totalDuration = rootMethod.executionEndTime;
   addNodeToMap(methodMap, rootMethod);
   metricList = [...methodMap.values()];
   return metricList; // return value for unit testing

--- a/log-viewer/modules/Timeline.ts
+++ b/log-viewer/modules/Timeline.ts
@@ -3,14 +3,7 @@
  */
 import { showTreeNode } from './TreeView';
 import formatDuration from './Util';
-import {
-  TimedNode,
-  Method,
-  RootNode,
-  TimelineKey,
-  truncated,
-  totalDuration,
-} from './parsers/TreeParser';
+import { TimedNode, Method, RootNode, TimelineKey, truncated } from './parsers/TreeParser';
 interface TimelineGroup {
   label: string;
   fillColor: string;
@@ -319,7 +312,7 @@ function drawTruncation(ctx: CanvasRenderingContext2D) {
     const thisEntry = truncated[i++],
       nextEntry = truncated[i] ?? {},
       startTime = thisEntry.timestamp,
-      endTime = nextEntry.timestamp ?? totalDuration;
+      endTime = nextEntry.timestamp ?? timelineRoot.executionEndTime;
 
     ctx.fillStyle = thisEntry.color;
     const x = startTime * state.zoom - state.offsetX;
@@ -350,7 +343,7 @@ function resize() {
     canvas.height = displayHeight = newHeight;
     ctx?.setTransform(1, 0, 0, 1, 0, displayHeight); // shift y-axis down so that 0,0 is bottom-lefts
 
-    const newDefaultZoom = newWidth / totalDuration;
+    const newDefaultZoom = newWidth / timelineRoot.executionEndTime;
     // defaults if not set yet
     state.defaultZoom ||= state.zoom ||= newDefaultZoom;
 
@@ -521,7 +514,7 @@ function findTruncatedTooltip(x: number): HTMLDivElement | null {
     const thisEntry = truncated[i++],
       nextEntry = truncated[i] ?? {},
       startTime = thisEntry.timestamp,
-      endTime = nextEntry.timestamp ?? totalDuration,
+      endTime = nextEntry.timestamp ?? timelineRoot.executionEndTime,
       startX = startTime * state.zoom - state.offsetX,
       endX = endTime * state.zoom - state.offsetX;
 
@@ -620,7 +613,7 @@ function handleMouseMove(evt: MouseEvent) {
   if (dragging) {
     tooltip.style.display = 'none';
     const { movementY, movementX } = evt;
-    const maxWidth = state.zoom * totalDuration - displayWidth;
+    const maxWidth = state.zoom * timelineRoot.executionEndTime - displayWidth;
     state.offsetX = Math.max(0, Math.min(maxWidth, state.offsetX - movementX));
 
     const maxVertOffset = ~~(realHeight - displayHeight + displayHeight / 4);
@@ -647,13 +640,13 @@ function handleScroll(evt: WheelEvent) {
       if (state.zoom !== oldZoom) {
         const timePosBefore = (lastMouseX + state.offsetX) / oldZoom;
         const newOffset = timePosBefore * state.zoom - lastMouseX;
-        const maxWidth = state.zoom * totalDuration - displayWidth;
+        const maxWidth = state.zoom * timelineRoot.executionEndTime - displayWidth;
         state.offsetX = Math.max(0, Math.min(maxWidth, newOffset));
       }
     }
     // movement when zooming
     else {
-      const maxWidth = state.zoom * totalDuration - displayWidth;
+      const maxWidth = state.zoom * timelineRoot.executionEndTime - displayWidth;
       state.offsetX = Math.max(0, Math.min(maxWidth, state.offsetX + deltaX));
     }
   }

--- a/log-viewer/modules/__tests__/TreeParser.test.ts
+++ b/log-viewer/modules/__tests__/TreeParser.test.ts
@@ -408,7 +408,8 @@ describe('getRootMethod tests', () => {
     // This should match the last node with a duration
     // The last log line is information only (duration is 0)
     // The last `FLOW_START_INTERVIEW_BEGIN` + `FLOW_START_INTERVIEW_END` are the last pair that will result in a duration
-    expect(rootMethod.exitStamp).toBe(1520000000);
+    expect(rootMethod.exitStamp).toBe(1530000000);
+    expect(rootMethod.executionEndTime).toBe(1520000000);
   });
 
   it('Root exitStamp should match last line timestamp if none of the line pairs have duration', async () => {
@@ -421,6 +422,7 @@ describe('getRootMethod tests', () => {
     parseLog(log);
     const rootMethod = getRootMethod();
     expect(rootMethod.exitStamp).toBe(1530000000);
+    expect(rootMethod.executionEndTime).toBe(0);
   });
 });
 


### PR DESCRIPTION
This was due to the endtime being used a the last log element with a duration. Now there are two properties on root for time
`executionEndTime` which is the endtime of the last node with a duration (the latest time that should be shown on timeline) `exitStamp` which is the end time of the lastest node regardless of duration.

This means the total time of the log will sometimes be different to the timeline time if there are log lines that show extra info e.g `CUMULATIVE_USAGE`

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

fixes #180 
