### PR TITLE
chore: add contributors to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,16 @@ Cliking on the links will take you to where that SOQL/DML occured in the call tr
 Help us to make things better by [Contributing](https://raw.githubusercontent.com/financialforcedev/debug-log-analyzer/main/lana/CONTRIBUTING.md)\
 Find out how to [Build](https://raw.githubusercontent.com/financialforcedev/debug-log-analyzer/main/lana/BUILDING.md) the extension
 
+## Contributors &#10084; &#128591;
+
+Thanks to the everyone who has contributed
+
+<p align="center">
+  <a href="https://github.com/financialforcedev/debug-log-analyzer/graphs/contributors">
+    <img src="https://contrib.rocks/image?repo=financialforcedev/debug-log-analyzer&max=25" />
+  </a>
+</p>
+
 ---
 
 <p align="center">


### PR DESCRIPTION
Use this image to show the first 25 contributors.
https://contrib.rocks/image?repo=financialforcedev/debug-log-analyzer&max=25 which shows this info
https://github.com/financialforcedev/debug-log-analyzer/graphs/contributors

# Description

Add this image the readme
<a href="https://github.com/financialforcedev/debug-log-analyzer/graphs/contributors">
    <img src="https://contrib.rocks/image?repo=financialforcedev/debug-log-analyzer&max=25" />
</a>

The image is from https://contrib.rocks/image?repo=financialforcedev/debug-log-analyzer&max=25 and will be updated :)

resolves #183 
