### PR TITLE
fix: `ENTERING_MANAGED_PKG` events not being displayed on timeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixes `ENTERING_MANAGED_PKG` events not being displayed on timeline ([#188][#188])
+
 ## [1.5.1] - 2022-10-04
 
 ### Fixed
@@ -166,3 +172,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#139]: https://github.com/financialforcedev/debug-log-analyzer/issues/139
 [#23]: https://github.com/financialforcedev/debug-log-analyzer/issues/23
 [#163]: https://github.com/financialforcedev/debug-log-analyzer/issues/163
+[#188]: https://github.com/financialforcedev/debug-log-analyzer/issues/188

--- a/log-viewer/modules/parsers/TreeParser.ts
+++ b/log-viewer/modules/parsers/TreeParser.ts
@@ -986,9 +986,9 @@ export class ExecutionFinishedLine extends Detail {
   }
 }
 
-class EnteringManagedPackageLine extends TimedNode {
+class EnteringManagedPackageLine extends Method {
   constructor(parts: string[]) {
-    super(parts, "method", "pkg");
+    super(parts, [], null, "method", "pkg");
     const rawNs = parts[2],
       lastDot = rawNs.lastIndexOf("."),
       ns = lastDot < 0 ? rawNs : rawNs.substring(lastDot + 1);
@@ -996,9 +996,8 @@ class EnteringManagedPackageLine extends TimedNode {
     this.text = this.namespace = ns;
   }
 
-  after(next: LogLine) {
-    this.exitStamp = next.timestamp;
-    this.duration = this.selfTime = this.exitStamp - this.timestamp;
+  onAfter(end: LogLine): void {
+    this.exitStamp = end.timestamp;
   }
 }
 


### PR DESCRIPTION
# Description

fix: `ENTERING_MANAGED_PKG` events not being displayed on timeline

## Type of change

- [X] Bug fix


fixes #188 
