### PR TITLE
chore: ENTERING_MANAGED_PKG performance

### DIFF
--- a/log-viewer/modules/Main.ts
+++ b/log-viewer/modules/Main.ts
@@ -5,7 +5,6 @@ import { showTab } from './Util';
 import parseLog, {
   getLogSettings,
   TimedNode,
-  Method,
   LogSetting,
   truncated,
   totalDuration,

--- a/log-viewer/modules/Main.ts
+++ b/log-viewer/modules/Main.ts
@@ -206,7 +206,6 @@ async function displayLog(log: string, name: string, path: string) {
 
   timer('analyse');
   await Promise.all([setNamespaces(rootMethod), markContainers(rootMethod)]);
-  await insertPackageWrappers(rootMethod);
   await Promise.all([analyseMethods(rootMethod), DatabaseAccess.create(rootMethod)]);
 
   await setStatus(name, path, 'Rendering...', 'black');

--- a/log-viewer/modules/Main.ts
+++ b/log-viewer/modules/Main.ts
@@ -106,58 +106,6 @@ async function markContainers(node: TimedNode) {
   }
 }
 
-async function insertPackageWrappers(node: Method) {
-  const children = node.children,
-    isParentDml = node.type === 'DML_BEGIN';
-
-  let lastPkg: TimedNode | null = null,
-    i = 0;
-  while (i < children.length) {
-    const child = children[i],
-      childType = child.type;
-
-    if (lastPkg && child instanceof TimedNode) {
-      if (childType === 'ENTERING_MANAGED_PKG' && child.namespace === lastPkg.namespace) {
-        // combine adjacent (like) packages
-        children.splice(i, 1); // remove redundant child from parent
-
-        lastPkg.exitStamp = child.exitStamp;
-        lastPkg.recalculateDurations();
-        continue; // skip any more child processing (it's gone)
-      } else if (
-        (isParentDml && (childType === 'DML_BEGIN' || childType === 'SOQL_EXECUTE_BEGIN')) ||
-        childType === 'EXCEPTION_THROWN'
-      ) {
-        // move child DML / SOQL into the last package
-        children.splice(i, 1); // remove moving child from parent
-        if (lastPkg.children) {
-          lastPkg.children.push(child); // move child into the pkg
-        }
-
-        lastPkg.totalDmlCount = child.totalDmlCount + (childType === 'DML_BEGIN' ? 1 : 0);
-        lastPkg.totalSoqlCount =
-          child.totalSoqlCount + (childType === 'SOQL_EXECUTE_BEGIN' ? 1 : 0);
-        lastPkg.totalThrownCount =
-          child.totalThrownCount + (childType === 'EXCEPTION_THROWN' ? 1 : 0);
-        lastPkg.exitStamp = child.exitStamp; // move the end
-        lastPkg.recalculateDurations();
-        if (child instanceof Method) {
-          await insertPackageWrappers(child);
-        }
-        continue; // skip any more child processing (it's moved)
-      } else {
-        ++i;
-      }
-    } else {
-      ++i;
-    }
-    if (child instanceof Method) {
-      await insertPackageWrappers(child);
-    }
-    lastPkg = childType === 'ENTERING_MANAGED_PKG' ? (child as TimedNode) : null;
-  }
-}
-
 let timerText: string, startTime: number;
 
 function timer(text: string) {

--- a/log-viewer/modules/__tests__/TreeParser.test.ts
+++ b/log-viewer/modules/__tests__/TreeParser.test.ts
@@ -12,6 +12,8 @@ import parseLog, {
   getLogSettings,
   Method,
   MethodEntryLine,
+  LogLine,
+  lineTypeMap,
   logLines,
   CodeUnitStartedLine,
   CodeUnitFinishedLine,
@@ -466,6 +468,40 @@ describe('getRootMethod tests', () => {
     expect(executionChildren[2].exitStamp).toBe(1100);
     expect(executionChildren[2].children.length).toBe(1);
     expect(executionChildren[2].children[0].type).toBe('DML_BEGIN');
+  });
+});
+
+describe('lineTypeMap tests', () => {
+  it('Lines referenced by exitTypes should be exits', () => {
+    for (const [_keyName, cls] of lineTypeMap) {
+      const line = new cls([
+        '14:32:07.563 (17358806534)',
+        'DUMMY',
+        '[10]',
+        'Rows:3',
+        '',
+        'Rows:5',
+      ]) as LogLine;
+      if (line instanceof Method) {
+        expect(line.exitTypes).not.toBe(null);
+        expect(line.isExit).toBe(false);
+        line.exitTypes.forEach((exitType) => {
+          const exitCls = lineTypeMap.get(exitType);
+          expect(exitCls).not.toBe(null);
+          if (exitCls) {
+            const exitLine = new exitCls([
+              '14:32:07.563 (17358806534)',
+              'DUMMY',
+              '[10]',
+              'Rows:3',
+              '',
+              'Rows:5',
+            ]) as LogLine;
+            expect(exitLine.isExit).toBe(true);
+          }
+        });
+      }
+    }
   });
 });
 

--- a/log-viewer/modules/__tests__/TreeParser.test.ts
+++ b/log-viewer/modules/__tests__/TreeParser.test.ts
@@ -458,14 +458,14 @@ describe('getRootMethod tests', () => {
     expect(executionChildren[1].type).toBe('ENTERING_MANAGED_PKG');
     expect(executionChildren[1].namespace).toBe('ns');
     expect(executionChildren[1].timestamp).toBe(400);
-    expect(executionChildren[1].exitStamp).toBe(600);
+    expect(executionChildren[1].exitStamp).toBe(700);
 
     expect(executionChildren[2].type).toBe('ENTERING_MANAGED_PKG');
     expect(executionChildren[2].namespace).toBe('ns2');
     expect(executionChildren[2].timestamp).toBe(700);
     expect(executionChildren[2].exitStamp).toBe(1100);
     expect(executionChildren[2].children.length).toBe(1);
-    expect(executionChildren[2].children[0].type).toBe('ENTERING_MANAGED_PKG');
+    expect(executionChildren[2].children[0].type).toBe('DML_BEGIN');
   });
 });
 

--- a/log-viewer/modules/components/CallStack.ts
+++ b/log-viewer/modules/components/CallStack.ts
@@ -34,7 +34,7 @@ export class CallStack extends LitElement {
     const stacks = DatabaseAccess.instance()?.stacks;
     if (stacks && this.stack >= 0 && this.stack < stacks.length) {
       const stack = stacks[this.stack];
-      if (stack) {
+      if (stack.length) {
         const details = stack.slice(1, 10).map((entry) => this.lineLink(entry, false));
         return html`<details>
           <summary>${this.lineLink(stack[0], true)}</summary>

--- a/log-viewer/modules/parsers/TreeParser.ts
+++ b/log-viewer/modules/parsers/TreeParser.ts
@@ -156,11 +156,13 @@ export class TimedNode extends LogLine {
 
   recalculateDurations() {
     if (this.exitStamp) {
-      this.selfTime = this.duration = this.exitStamp - this.timestamp;
+      this.duration = this.exitStamp - this.timestamp;
 
+      let childDuration = 0;
       this.children.forEach((child) => {
-        this.selfTime -= child.duration;
+        childDuration += child.duration;
       });
+      this.selfTime = this.duration - childDuration;
     }
   }
 }

--- a/log-viewer/modules/parsers/TreeParser.ts
+++ b/log-viewer/modules/parsers/TreeParser.ts
@@ -2237,7 +2237,7 @@ function insertPackageWrappers(node: Method) {
     if (lastPkg && child instanceof TimedNode) {
       if (isPkgType && child.namespace === lastPkg.namespace) {
         // combine adjacent (like) packages
-        lastPkg.exitStamp = child.exitStamp;
+        lastPkg.exitStamp = child.exitStamp || child.timestamp;
         continue; // skip any more child processing (it's gone)
       } else if (!isPkgType) {
         // move child DML / SOQL into the last package
@@ -2250,7 +2250,7 @@ function insertPackageWrappers(node: Method) {
           child.totalSoqlCount + (childType === 'SOQL_EXECUTE_BEGIN' ? 1 : 0);
         lastPkg.totalThrownCount =
           child.totalThrownCount + (childType === 'EXCEPTION_THROWN' ? 1 : 0);
-        lastPkg.exitStamp = child.exitStamp; // move the end
+        lastPkg.exitStamp = child.exitStamp || child.timestamp; // move the end
 
         if (child instanceof Method) {
           insertPackageWrappers(child);

--- a/log-viewer/modules/parsers/TreeParser.ts
+++ b/log-viewer/modules/parsers/TreeParser.ts
@@ -1966,7 +1966,7 @@ class DuplicateDetectionRule extends Detail {
   }
 }
 
-const lineTypeMap = new Map<string, new (parts: string[]) => LogLine>([
+export const lineTypeMap = new Map<string, new (parts: string[]) => LogLine>([
   ['BULK_HEAP_ALLOCATE', BulkHeapAllocateLine],
   ['CALLOUT_REQUEST', CalloutRequestLine],
   ['CALLOUT_RESPONSE', CalloutResponseLine],


### PR DESCRIPTION
# Description

Improves performance pf processing `ENTERING_MANAGED_PKG` events
Processing 20000 `ENTERING_MANAGED_PKG` events goes from ~4.5s to ~94ms
Mainly done by replacing editing current child list with `splice` to overriding the child array with an assignment instead

It also means a `ENTERING_MANAGED_PKG` event will span the whole of a `METHOD_ENTRY` event and will cause nesting

Since the `ENTERING_MANAGED_PKG` is generally noise when you can see the content (via subscriber).
It probably makes more sense to remove the `ENTERING_MANAGED_PKG` events if there are other children e.g we can see the namespace method calls for the managed package anyway .
