### PR TITLE
chore: fix badge urls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: '16'
       - name: Install vsce
-        run: npm install --global vsce
+        run: npm install --global @vscode/vsce
       - name: Dependencies
         run: |
           npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,4 @@ jobs:
         run: npm ci
       - name: Tests
         run: |
-          cd log-viewer
           npm run test:ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: '16'
       - name: Install vsce + ovsx
         run: |
-          npm install --global vsce
+          npm install --global @vscode/vsce
           npm install --global ovsx
       - name: Dependencies
         run: |

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -13,7 +13,7 @@ The lana directory contain the extension source code. The log-viewer directory c
 VSCE is only required to create .vsix files for distribution. It can be installed globally with
 
 ```zsh
-npm i -g vsce
+npm i -g @vscode/vsce
 ```
 
 ## Local Development

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Apex Log Analyzer for Salesforce
 
-[![Version](https://vsmarketplacebadge.apphb.com/version-short/financialforce.lana.svg)](https://marketplace.visualstudio.com/items?itemName=financialforce.lana)
-[![Download](https://vsmarketplacebadge.apphb.com/downloads-short/financialforce.lana.svg)](https://marketplace.visualstudio.com/items?itemName=financialforce.lana)
-[![Installs](https://vsmarketplacebadge.apphb.com/installs-short/financialforce.lana.svg)](https://marketplace.visualstudio.com/items?itemName=financialforce.lana)
-[![Ratings](https://vsmarketplacebadge.apphb.com/rating-short/financialforce.lana.svg)](https://marketplace.visualstudio.com/items?itemName=financialforce.lana)
+[![Version](https://vsmarketplacebadges.dev/version-short/financialforce.lana.svg)](https://marketplace.visualstudio.com/items?itemName=financialforce.lana)
+[![Download](https://vsmarketplacebadges.dev/downloads-short/financialforce.lana.svg)](https://marketplace.visualstudio.com/items?itemName=financialforce.lana)
+[![Installs](https://vsmarketplacebadges.dev/installs-short/financialforce.lana.svg)](https://marketplace.visualstudio.com/items?itemName=financialforce.lana)
+[![Ratings](https://vsmarketplacebadges.dev/rating-short/financialforce.lana.svg)](https://marketplace.visualstudio.com/items?itemName=financialforce.lana)
 
 Apex Log Analyzer makes performance analysis of Salesforce debug logs much easier and quicker. It provides visualization of code execution via a Flamegraph and Calltree and helps identify performance and SOQL/DML problems via Method and Database Analysis.
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,32 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+  projects: [
+    {
+      displayName: 'log-viewer',
+      globals: {
+        'ts-jest': {
+          isolatedModules: true,
+          tsconfig: {
+            // allow js in typescript
+            allowJs: true,
+          },
+        },
+      },
+      moduleNameMapper: {
+        '^.+\\.(css|less)$': '<rootDir>/resources/css/stub.js',
+      },
+      rootDir: '<rootDir>/log-viewer',
+      testEnvironment: 'node',
+      preset: 'ts-jest',
+      transform: {
+        // transform files with ts-jest
+        '^.+\\.(ts|js)?$': 'ts-jest',
+      },
+      transformIgnorePatterns: [
+        // allow lit/@lit transformation
+        '<rootDir>/node_modules/(?!@?lit)',
+      ],
+      testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/out/'],
+    },
+  ],
+};

--- a/log-viewer/modules/__tests__/Database.test.ts
+++ b/log-viewer/modules/__tests__/Database.test.ts
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2020 FinancialForce.com, inc. All rights reserved.
- * @jest-environment jsdom
  */
 import { DatabaseAccess, DatabaseEntry } from '../Database';
 import parseLog from '../parsers/TreeParser';

--- a/log-viewer/modules/__tests__/SOQLParser.test.ts
+++ b/log-viewer/modules/__tests__/SOQLParser.test.ts
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2020 FinancialForce.com, inc. All rights reserved.
- * @jest-environment jsdom
  */
 
 import { SOQLParser, SyntaxException } from '../parsers/SOQLParser';

--- a/log-viewer/modules/__tests__/TreeView.test.ts
+++ b/log-viewer/modules/__tests__/TreeView.test.ts
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2020 FinancialForce.com, inc. All rights reserved.
- * @jest-environment jsdom
  */
 
 import parseLog, { logLines } from '../parsers/TreeParser';

--- a/log-viewer/package.json
+++ b/log-viewer/package.json
@@ -3,8 +3,6 @@
   "name": "logviewer",
   "private": true,
   "scripts": {
-    "test": "jest",
-    "test:ci": "jest --runInBand",
     "build": "rollup -c rollup.config.js",
     "lint": "eslint modules --ext ts",
     "watch": "rollup -w -c rollup.config.js",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "build:dev": "rm -rf lana/out && rollup -c rollup.config.js",
     "watch": "rm -rf lana/out && rollup -w -c rollup.config.js",
     "prepare": "husky install",
-    "lint": "eslint . --ext ts"
+    "lint": "eslint . --ext ts",
+    "test": "jest",
+    "test:ci": "jest --runInBand"
   },
   "lint-staged": {
     "*.{ts,css,md}": "prettier --write"


### PR DESCRIPTION
# Description

The url for https://vsmarketplacebadges.apphd/ got changed to https://vsmarketplacebadges.dev/
so we need to update it to get the badges working again.

Alternatively we could use https://shields.io/ as they have the same badges

See https://github.com/cssho/VSMarketplaceBadge/issues/18#issuecomment-1284739771 and https://github.com/microsoft/vscode-react-native/pull/1893/files for more info

![image](https://user-images.githubusercontent.com/81575432/211626979-9edc8a21-9a98-49b9-a611-a0b740f137a8.png)

resolves #207 
