### PR TITLE
feat: add rowcount to timeline tooltip for `SOSL`, `SOQL` + `DML` events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Breadcrumbs shown above the calltree when clicking a row ([#142][#142])
 - `Log: Show Apex Log Analysis` code lens to the top of the currently open log file ([#199][#199])
   - This is a faster way to open the analysis
+- Support for more file types when showing the analysis ([#199][#199])
+  - The analysis can now be shown for any `.log` or `.txt` file that starts with the Apex debug log header
+  - e.g `57.0 APEX_CODE,FINE;APEX_PROFILING,FINE;CALLOUT,NONE;DB,FINEST;NBA,INFO;SYSTEM,DEBUG;VALIDATION,INFO;VISUALFORCE,FINE;WAVE,INFO;WORKFLOW,INFO`
 - Redesigned Database tab ([#219][#219])
   - All columns are sortable ascending /descending by clicking the header
   - Added columns DML/ SOQL, Row Count, Total Time
@@ -23,9 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Goto code from click to CMD/CTRL and click. Breadcrumbs are shown on click instead ([#142][#142])
-- Support more file types when showing the analysis ([#199][#199])
-  - The analysis can now be shown for any `.log` or `.txt` file that starts with the Apex debug log header
-  - e.g `57.0 APEX_CODE,FINE;APEX_PROFILING,FINE;CALLOUT,NONE;DB,FINEST;NBA,INFO;SYSTEM,DEBUG;VALIDATION,INFO;VISUALFORCE,FINE;WAVE,INFO;WORKFLOW,INFO`
 
 ### Fixed
 
@@ -207,3 +207,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#212]: https://github.com/financialforcedev/debug-log-analyzer/issues/212
 [#199]: https://github.com/financialforcedev/debug-log-analyzer/issues/199
 [#219]: https://github.com/financialforcedev/debug-log-analyzer/issues/219
+[#129]: https://github.com/financialforcedev/debug-log-analyzer/issues/129

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added specific columns for SOQL Selectivity + Aggregations
   - Added detail panel which is shown by clicking a row which shows the call stack for the specific DML / SOQL, clicking a link will go to the main call tree tab
   - Totals shown at the bottom of each column
+- The row count to the timeline tooltip for events which have one e.g `SOQL_EXECUTE_BEGIN`, `DML_BEGIN`, `SOSL_EXECUTE_BEGIN` ([#129][#129])
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Apex Log Analyzer makes performance analysis of Salesforce debug logs much easier and quicker. It provides visualization of code execution via a Flamegraph and Calltree and helps identify performance and SOQL/DML problems via Method and Database Analysis.
 
-![preview](https://raw.githubusercontent.com/financialforcedev/debug-log-analyzer/main/lana/v1.6/images/lana-preview.gif)
+![preview](https://raw.githubusercontent.com/financialforcedev/debug-log-analyzer/main/lana/dist/v1.6/lana-preview.gif)
 
 ## WARNING
 

--- a/log-viewer/modules/Timeline.ts
+++ b/log-viewer/modules/Timeline.ts
@@ -491,12 +491,18 @@ function findTimelineTooltip(x: number, depth: number): HTMLDivElement | null {
         toolTip.appendChild(
           document.createTextNode(`duration: ${formatDuration(target.duration)}`)
         );
+
         if (target.cpuType === 'free') {
           toolTip.appendChild(document.createTextNode(' (free)'));
         } else {
           toolTip.appendChild(
             document.createTextNode(` (self ${formatDuration(target.selfTime)})`)
           );
+        }
+
+        if (target.rowCount !== null) {
+          toolTip.appendChild(brElem.cloneNode());
+          toolTip.appendChild(document.createTextNode(`rows: ${target.rowCount}`));
         }
       }
     }


### PR DESCRIPTION
# Description

- Adds the row count to the timeline tooltip for any event what has one.
- e.g `SOSL`, `SOQL` + `DML` events
- This includes showing 0 when appropriate.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

### Any images/ gifs (if appropriate)
<img width="258" alt="image" src="https://user-images.githubusercontent.com/4013877/221821092-5b4fcecb-3724-469b-b2d6-7ce8a430e0e7.png">

resolves #129 
