### PR TITLE
chore: replace rollup-plugin-terser with @rollup/plugin-terser

### DIFF
--- a/lana/package.json
+++ b/lana/package.json
@@ -162,6 +162,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^22.0.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
+    "@rollup/plugin-terser": "^0.4.0",
     "@rollup/plugin-typescript": "^8.0.0",
     "@types/node": "^16.x.x",
     "@types/vscode": "^1.0.0",
@@ -171,7 +172,6 @@
     "eslint-plugin-prettier": "^4.2.1",
     "prettier": "^2.7.1",
     "rollup": "^2.0.0",
-    "rollup-plugin-terser": "^7.0.0",
     "tslib": "^2.0.0",
     "typescript": "^4.0.0"
   }

--- a/lana/rollup.config.js
+++ b/lana/rollup.config.js
@@ -1,6 +1,6 @@
 import commonjs from '@rollup/plugin-commonjs';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
-import { terser } from 'rollup-plugin-terser';
+import terser from '@rollup/plugin-terser';
 import typescript from '@rollup/plugin-typescript';
 
 const compact = !process.env.ROLLUP_WATCH;

--- a/log-viewer/package.json
+++ b/log-viewer/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^22.x.x",
     "@rollup/plugin-node-resolve": "^13.0.0",
+    "@rollup/plugin-terser": "^0.4.0",
     "@rollup/plugin-typescript": "^8.0.0",
     "@types/jest": "^28.x.x",
     "@types/tabulator-tables": "^5.4.3",
@@ -35,7 +36,6 @@
     "prettier": "^2.7.1",
     "rollup": "^2.0.0",
     "rollup-plugin-postcss": "^4.0.0",
-    "rollup-plugin-terser": "^7.0.0",
     "ts-jest": "^28.0.0",
     "tslib": "^2.0.0",
     "typescript": "^4.0.0"

--- a/log-viewer/rollup.config.js
+++ b/log-viewer/rollup.config.js
@@ -1,9 +1,9 @@
 // Rollup plugins
 import commonjs from '@rollup/plugin-commonjs';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
-import postcss from 'rollup-plugin-postcss';
-import { terser } from 'rollup-plugin-terser';
+import terser from '@rollup/plugin-terser';
 import typescript from '@rollup/plugin-typescript';
+import postcss from 'rollup-plugin-postcss';
 
 const compact = !process.env.ROLLUP_WATCH;
 export default {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       "devDependencies": {
         "@rollup/plugin-commonjs": "^22.0.0",
         "@rollup/plugin-node-resolve": "^13.0.0",
+        "@rollup/plugin-terser": "^0.4.0",
         "@rollup/plugin-typescript": "^8.0.0",
         "@types/node": "^16.x.x",
         "@types/vscode": "^1.0.0",
@@ -34,7 +35,6 @@
         "eslint-plugin-prettier": "^4.2.1",
         "prettier": "^2.7.1",
         "rollup": "^2.0.0",
-        "rollup-plugin-terser": "^7.0.0",
         "tslib": "^2.0.0",
         "typescript": "^4.0.0"
       },
@@ -59,6 +59,7 @@
       "devDependencies": {
         "@rollup/plugin-commonjs": "^22.x.x",
         "@rollup/plugin-node-resolve": "^13.0.0",
+        "@rollup/plugin-terser": "^0.4.0",
         "@rollup/plugin-typescript": "^8.0.0",
         "@types/jest": "^28.x.x",
         "@types/tabulator-tables": "^5.4.3",
@@ -75,7 +76,6 @@
         "prettier": "^2.7.1",
         "rollup": "^2.0.0",
         "rollup-plugin-postcss": "^4.0.0",
-        "rollup-plugin-terser": "^7.0.0",
         "ts-jest": "^28.0.0",
         "tslib": "^2.0.0",
         "typescript": "^4.0.0"
@@ -1374,6 +1374,37 @@
       },
       "peerDependencies": {
         "rollup": "^2.42.0"
+      }
+    },
+    "node_modules/@rollup/plugin-terser": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.0.tgz",
+      "integrity": "sha512-Ipcf3LPNerey1q9ZMjiaWHlNPEHNU/B5/uh9zXLltfEQ1lVSLLeZSgAtTPWGyw8Ip1guOeq+mDtdOlEj/wNxQw==",
+      "dev": true,
+      "dependencies": {
+        "serialize-javascript": "^6.0.0",
+        "smob": "^0.0.6",
+        "terser": "^5.15.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.x || ^3.x"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-terser/node_modules/serialize-javascript": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
+      "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
       }
     },
     "node_modules/@rollup/plugin-typescript": {
@@ -5438,20 +5469,6 @@
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
-    "node_modules/jest-worker": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
-      "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
     "node_modules/js-base64": {
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
@@ -8244,21 +8261,6 @@
         "postcss": "8.x"
       }
     },
-    "node_modules/rollup-plugin-terser": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
-      "integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "jest-worker": "^26.2.1",
-        "serialize-javascript": "^4.0.0",
-        "terser": "^5.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^2.0.0"
-      }
-    },
     "node_modules/rollup-pluginutils": {
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
@@ -8408,15 +8410,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/serialize-javascript": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
-      "dev": true,
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -8537,6 +8530,12 @@
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
       }
+    },
+    "node_modules/smob": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/smob/-/smob-0.0.6.tgz",
+      "integrity": "sha512-V21+XeNni+tTyiST1MHsa84AQhT1aFZipzPpOFAVB8DkHzwJyjjAmt9bgwnuZiZWnIbMo2duE29wybxv/7HWUw==",
+      "dev": true
     },
     "node_modules/socks": {
       "version": "2.7.1",
@@ -10598,6 +10597,28 @@
         "is-builtin-module": "^3.1.0",
         "is-module": "^1.0.0",
         "resolve": "^1.19.0"
+      }
+    },
+    "@rollup/plugin-terser": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.0.tgz",
+      "integrity": "sha512-Ipcf3LPNerey1q9ZMjiaWHlNPEHNU/B5/uh9zXLltfEQ1lVSLLeZSgAtTPWGyw8Ip1guOeq+mDtdOlEj/wNxQw==",
+      "dev": true,
+      "requires": {
+        "serialize-javascript": "^6.0.0",
+        "smob": "^0.0.6",
+        "terser": "^5.15.1"
+      },
+      "dependencies": {
+        "serialize-javascript": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
+          "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+          "dev": true,
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
+        }
       }
     },
     "@rollup/plugin-typescript": {
@@ -13673,17 +13694,6 @@
         "string-length": "^4.0.1"
       }
     },
-    "jest-worker": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
-      "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^7.0.0"
-      }
-    },
     "js-base64": {
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
@@ -13807,6 +13817,7 @@
         "@apexdevtools/apex-ls": "^3.1.0",
         "@rollup/plugin-commonjs": "^22.0.0",
         "@rollup/plugin-node-resolve": "^13.0.0",
+        "@rollup/plugin-terser": "*",
         "@rollup/plugin-typescript": "^8.0.0",
         "@types/node": "^16.x.x",
         "@types/vscode": "^1.0.0",
@@ -13816,7 +13827,6 @@
         "eslint-plugin-prettier": "^4.2.1",
         "prettier": "^2.7.1",
         "rollup": "^2.0.0",
-        "rollup-plugin-terser": "^7.0.0",
         "tslib": "^2.0.0",
         "typescript": "^4.0.0"
       },
@@ -14131,9 +14141,10 @@
         "@apexdevtools/apex-parser": "^3.0.0",
         "@rollup/plugin-commonjs": "^22.x.x",
         "@rollup/plugin-node-resolve": "^13.0.0",
+        "@rollup/plugin-terser": "^0.4.0",
         "@rollup/plugin-typescript": "^8.0.0",
         "@types/jest": "^28.x.x",
-        "@types/tabulator-tables": "*",
+        "@types/tabulator-tables": "^5.4.3",
         "@typescript-eslint/eslint-plugin": "^5.x.x",
         "@typescript-eslint/parser": "^5.x.x",
         "concurrently": "^7.x.x",
@@ -14148,7 +14159,6 @@
         "prettier": "^2.7.1",
         "rollup": "^2.0.0",
         "rollup-plugin-postcss": "^4.0.0",
-        "rollup-plugin-terser": "^7.0.0",
         "tabulator-tables": "^5.4.3",
         "ts-jest": "^28.0.0",
         "tslib": "^2.0.0",
@@ -15739,18 +15749,6 @@
         "style-inject": "^0.3.0"
       }
     },
-    "rollup-plugin-terser": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
-      "integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.10.4",
-        "jest-worker": "^26.2.1",
-        "serialize-javascript": "^4.0.0",
-        "terser": "^5.0.0"
-      }
-    },
     "rollup-pluginutils": {
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
@@ -15858,15 +15856,6 @@
         "lru-cache": "^6.0.0"
       }
     },
-    "serialize-javascript": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
-      "dev": true,
-      "requires": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -15951,6 +15940,12 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true
+    },
+    "smob": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/smob/-/smob-0.0.6.tgz",
+      "integrity": "sha512-V21+XeNni+tTyiST1MHsa84AQhT1aFZipzPpOFAVB8DkHzwJyjjAmt9bgwnuZiZWnIbMo2duE29wybxv/7HWUw==",
       "dev": true
     },
     "socks": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,10 +1,10 @@
 // Rollup plugins
 import commonjs from '@rollup/plugin-commonjs';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
-import postcss from 'rollup-plugin-postcss';
-import { terser } from 'rollup-plugin-terser';
+import terser from '@rollup/plugin-terser';
 import typescript from '@rollup/plugin-typescript';
 import copy from 'rollup-plugin-copy';
+import postcss from 'rollup-plugin-postcss';
 
 const production = process.env.NODE_ENV == 'production';
 console.log('Package mode:', production ? 'production' : 'development');


### PR DESCRIPTION
rollup-plugin-terser is no longer maintained switching to @rollup/plugin-terser instead.

# Description
- chore: replace rollup-plugin-terser with @rollup/plugin-terser

