### PR TITLE
bug: timeline tooltip disappears on zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Timeline not showing events if the event occurs outside the `EXECUTION_STARTED` + `EXECUTION_FINISHED` events ([#180][#180])
 - Timeline incorrectly showing some `VF_APEX_CALL_START` events when dealing with ApexPage messages ([#212][#212])
+- Timeline tooltip not shown when zooming ([#242][#242])
 - Font sizes not correctly scaling in some places ([#238][#238])
 
 ## [1.5.2] - 2022-11-08
@@ -210,3 +211,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#219]: https://github.com/financialforcedev/debug-log-analyzer/issues/219
 [#129]: https://github.com/financialforcedev/debug-log-analyzer/issues/129
 [#238]: https://github.com/financialforcedev/debug-log-analyzer/issues/238
+[#242]: https://github.com/financialforcedev/debug-log-analyzer/issues/242

--- a/log-viewer/modules/Timeline.ts
+++ b/log-viewer/modules/Timeline.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2020 FinancialForce.com, inc. All rights reserved.
  */
 import { showTreeNode } from './TreeView';
-import formatDuration from './Util';
+import formatDuration, { debounce } from './Util';
 import { TimedNode, Method, RootNode, TimelineKey, truncated } from './parsers/TreeParser';
 interface TimelineGroup {
   label: string;
@@ -586,7 +586,7 @@ function onMouseMove(evt: MouseEvent) {
     if (clRect) {
       lastMouseX = evt.clientX - clRect.left;
       lastMouseY = evt.clientY - clRect.top;
-      showTooltip(lastMouseX, lastMouseY);
+      debounce(showTooltip(lastMouseX, lastMouseY));
     }
   }
 }
@@ -612,6 +612,7 @@ function handleMouseDown(): void {
 }
 
 function handleMouseUp(): void {
+  debounce(showTooltip(lastMouseX, lastMouseY));
   dragging = false;
 }
 
@@ -629,7 +630,6 @@ function handleMouseMove(evt: MouseEvent) {
 
 function handleScroll(evt: WheelEvent) {
   if (!dragging) {
-    tooltip.style.display = 'none';
     evt.stopPropagation();
     const { deltaY, deltaX } = evt;
 
@@ -655,6 +655,7 @@ function handleScroll(evt: WheelEvent) {
       const maxWidth = state.zoom * timelineRoot.executionEndTime - displayWidth;
       state.offsetX = Math.max(0, Math.min(maxWidth, state.offsetX + deltaX));
     }
+    debounce(showTooltip(lastMouseX, lastMouseY));
   }
 }
 

--- a/log-viewer/modules/Timeline.ts
+++ b/log-viewer/modules/Timeline.ts
@@ -592,7 +592,8 @@ function onMouseMove(evt: MouseEvent) {
 }
 
 function onClickCanvas(): void {
-  if (!dragging && tooltip.style.display === 'block') {
+  const isClick = mouseDownPosition.x === lastMouseX && mouseDownPosition.y === lastMouseY;
+  if (!dragging && isClick) {
     const depth = ~~(((displayHeight - lastMouseY - state.offsetY) / realHeight) * maxY);
     const target = findByPosition(timelineRoot, 0, lastMouseX, depth);
     if (target && target.timestamp) {
@@ -607,18 +608,23 @@ function onLeaveCanvas() {
 }
 
 let dragging = false;
+let mouseDownPosition: { x: number; y: number };
 function handleMouseDown(): void {
   dragging = true;
+  tooltip.style.display = 'none';
+  mouseDownPosition = {
+    x: lastMouseX,
+    y: lastMouseY,
+  };
 }
 
 function handleMouseUp(): void {
-  debounce(showTooltip(lastMouseX, lastMouseY));
   dragging = false;
+  debounce(showTooltip(lastMouseX, lastMouseY));
 }
 
 function handleMouseMove(evt: MouseEvent) {
   if (dragging) {
-    tooltip.style.display = 'none';
     const { movementY, movementX } = evt;
     const maxWidth = state.zoom * timelineRoot.executionEndTime - displayWidth;
     state.offsetX = Math.max(0, Math.min(maxWidth, state.offsetX - movementX));

--- a/log-viewer/modules/Util.ts
+++ b/log-viewer/modules/Util.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2020 FinancialForce.com, inc. All rights reserved.
  */
-let timeout: number;
+let requestId: number;
 
 export default function formatDuration(duration: number) {
   const text = `${~~(duration / 1000)}`; // convert from nano-seconds to micro-seconds
@@ -27,11 +27,11 @@ export function showTab(tabId: string) {
 }
 
 export function debounce(callBack: void) {
-  if (timeout) {
-    window.cancelAnimationFrame(timeout);
+  if (requestId) {
+    window.cancelAnimationFrame(requestId);
   }
 
-  timeout = window.requestAnimationFrame(() => {
+  requestId = window.requestAnimationFrame(() => {
     callBack;
   });
 }

--- a/log-viewer/modules/Util.ts
+++ b/log-viewer/modules/Util.ts
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2020 FinancialForce.com, inc. All rights reserved.
  */
+let timeout: number;
+
 export default function formatDuration(duration: number) {
   const text = `${~~(duration / 1000)}`; // convert from nano-seconds to micro-seconds
   const textPadded = text.length < 4 ? '0000'.substring(text.length) + text : text; // length min = 4
@@ -22,4 +24,14 @@ export function showTab(tabId: string) {
   if (tabItem) {
     tabItem.classList.add('selected');
   }
+}
+
+export function debounce(callBack: void) {
+  if (timeout) {
+    window.cancelAnimationFrame(timeout);
+  }
+
+  timeout = window.requestAnimationFrame(() => {
+    callBack;
+  });
 }


### PR DESCRIPTION
# Description

- Fixes the timeline tooltip to remain visible when scrolling
- Also improves performance by adding debounce on scroll and mouse move that will ensure the tootlip is only rendered on the next animation frame.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

### Any images/ gifs (if appropriate)
![tooltip-scroll](https://user-images.githubusercontent.com/4013877/235094017-30c5113f-e8ad-464d-b889-94b47b3f7c83.gif)

fixes #242 
