### PR TITLE
ci: cache node modules for ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '16'
+          cache: 'npm'
       - name: Install vsce
         run: npm install --global @vscode/vsce
       - name: Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '16.x'
+          cache: 'npm'
       - name: Install Packages
         run: npm ci
       - name: Lint Files
@@ -31,6 +32,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '16'
+          cache: 'npm'
       - name: Install Packages
         run: npm ci
       - name: Tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '16'
+          cache: 'npm'
       - name: Install vsce + ovsx
         run: |
           npm install --global @vscode/vsce


### PR DESCRIPTION
# Description

Speeds up the builds by caching the node_modules folder and reusing in future builds.
Use a hash of `package-lock.json` as the key.

## Type of change

- [X] CI

resolves #266 
